### PR TITLE
refactor: update layout managers to use prong::Component

### DIFF
--- a/include/bombfork/prong/layout/grid_layout.h
+++ b/include/bombfork/prong/layout/grid_layout.h
@@ -60,7 +60,7 @@ public:
    * @param components List of components to measure
    * @return Calculated dimensions
    */
-  Dimensions measureLayout(const std::vector<std::shared_ptr<Component>>& components) override {
+  Dimensions measureLayout(const std::vector<bombfork::prong::Component*>& components) override {
     size_t rows = calculateRows(components);
     size_t cols = config_.columns;
 
@@ -69,7 +69,7 @@ public:
 
     // Measure cell sizes
     for (size_t i = 0; i < components.size(); ++i) {
-      auto componentSize = components[i]->measure();
+      auto componentSize = components[i]->getPreferredSize();
       size_t row = i / cols;
       size_t col = i % cols;
 
@@ -92,7 +92,7 @@ public:
    * @param components List of components to layout
    * @param availableSpace Total available space
    */
-  void layout(std::vector<std::shared_ptr<Component>>& components, const Dimensions& availableSpace) override {
+  void layout(std::vector<bombfork::prong::Component*>& components, const Dimensions& availableSpace) override {
     size_t rows = calculateRows(components);
     size_t cols = config_.columns;
 
@@ -101,7 +101,7 @@ public:
 
     // First pass: determine cell sizes
     for (size_t i = 0; i < components.size(); ++i) {
-      auto componentSize = components[i]->measure();
+      auto componentSize = components[i]->getPreferredSize();
       size_t row = i / cols;
       size_t col = i % cols;
 
@@ -127,8 +127,8 @@ public:
         if (index >= components.size())
           break;
 
-        auto& component = components[index];
-        auto componentSize = component->measure();
+        auto* component = components[index];
+        auto componentSize = component->getPreferredSize();
 
         Rect cellBounds{currentX, currentY, columnWidths[col], rowHeights[row]};
 
@@ -151,7 +151,8 @@ public:
           break;
         }
 
-        component->setBounds(cellBounds);
+        component->setBounds(static_cast<int>(cellBounds.x), static_cast<int>(cellBounds.y),
+                             static_cast<int>(cellBounds.width), static_cast<int>(cellBounds.height));
         currentX += columnWidths[col] + config_.horizontalSpacing;
       }
       currentY += rowHeights[row] + config_.verticalSpacing;
@@ -164,7 +165,7 @@ private:
    * @param components List of components
    * @return Number of rows
    */
-  size_t calculateRows(const std::vector<std::shared_ptr<Component>>& components) const {
+  size_t calculateRows(const std::vector<bombfork::prong::Component*>& components) const {
     if (config_.rows > 0)
       return config_.rows;
     return std::ceil(static_cast<float>(components.size()) / config_.columns);

--- a/include/bombfork/prong/layout/layout_manager.h
+++ b/include/bombfork/prong/layout/layout_manager.h
@@ -3,10 +3,12 @@
 #include <memory>
 #include <vector>
 
-namespace bombfork::prong::layout {
-
-// Forward declarations
+namespace bombfork::prong {
+// Forward declaration of prong::Component
 class Component;
+} // namespace bombfork::prong
+
+namespace bombfork::prong::layout {
 
 /**
  * @brief Basic dimensions structure
@@ -28,6 +30,10 @@ struct Rect {
 
 /**
  * @brief Base layout manager class using CRTP
+ *
+ * Layout managers now work directly with prong::Component pointers.
+ * Components are owned by their parent via unique_ptr and passed to
+ * layout managers as raw pointers for positioning.
  */
 template <typename DerivedT>
 class LayoutManager {
@@ -37,28 +43,15 @@ public:
   /**
    * @brief Measure required space for components
    */
-  virtual Dimensions measureLayout(const std::vector<std::shared_ptr<Component>>& components) = 0;
+  virtual Dimensions measureLayout(const std::vector<bombfork::prong::Component*>& components) = 0;
 
   /**
    * @brief Layout components within available space
    */
-  virtual void layout(std::vector<std::shared_ptr<Component>>& components, const Dimensions& availableSpace) = 0;
+  virtual void layout(std::vector<bombfork::prong::Component*>& components, const Dimensions& availableSpace) = 0;
 
 protected:
   LayoutManager() = default;
-};
-
-/**
- * @brief Minimal component interface for layout testing
- */
-class Component {
-public:
-  virtual ~Component() = default;
-  virtual Dimensions measure() const { return {100, 30}; }
-  virtual Dimensions measureLayout() const { return measure(); }
-  virtual void setBounds(const Rect& bounds) { (void)bounds; }
-  virtual void setPosition(const Rect& position) { setBounds(position); }
-  virtual void setSize(const Rect& size) { setBounds(size); }
 };
 
 } // namespace bombfork::prong::layout

--- a/include/bombfork/prong/layout/stack_layout.h
+++ b/include/bombfork/prong/layout/stack_layout.h
@@ -67,11 +67,11 @@ public:
    * @param components List of components to measure
    * @return Calculated dimensions
    */
-  Dimensions measureLayout(const std::vector<std::shared_ptr<Component>>& components) override {
+  Dimensions measureLayout(const std::vector<bombfork::prong::Component*>& components) override {
     Dimensions totalSize{0, 0};
 
-    for (const auto& component : components) {
-      auto componentSize = component->measure();
+    for (const auto* component : components) {
+      auto componentSize = component->getPreferredSize();
 
       if (config_.orientation == StackOrientation::VERTICAL) {
         totalSize.height += componentSize.height + config_.spacing;
@@ -96,15 +96,15 @@ public:
    * @param components List of components to layout
    * @param availableSpace Total available space
    */
-  void layout(std::vector<std::shared_ptr<Component>>& components, const Dimensions& availableSpace) override {
+  void layout(std::vector<bombfork::prong::Component*>& components, const Dimensions& availableSpace) override {
     if (components.empty())
       return;
 
     (void)measureLayout(components); // Unused but kept for potential future use
     float currentOffset = 0.0f;
 
-    for (auto& component : components) {
-      auto componentSize = component->measure();
+    for (auto* component : components) {
+      auto componentSize = component->getPreferredSize();
       Rect componentBounds{0, 0, static_cast<float>(componentSize.width), static_cast<float>(componentSize.height)};
 
       // Determine main and cross axis sizes
@@ -146,7 +146,8 @@ public:
       }
 
       // Set component bounds and advance offset
-      component->setBounds(componentBounds);
+      component->setBounds(static_cast<int>(componentBounds.x), static_cast<int>(componentBounds.y),
+                           static_cast<int>(componentBounds.width), static_cast<int>(componentBounds.height));
       currentOffset += mainSize + config_.spacing;
     }
   }

--- a/tests/test_component.cpp
+++ b/tests/test_component.cpp
@@ -35,13 +35,12 @@ public:
 template <typename DerivedT>
 class TestLayoutManager : public layout::LayoutManager<DerivedT> {
 public:
-  layout::Dimensions measureLayout(const std::vector<std::shared_ptr<layout::Component>>& components) override {
+  layout::Dimensions measureLayout(const std::vector<Component*>& components) override {
     (void)components;
     return {100, 50};
   }
 
-  void layout(std::vector<std::shared_ptr<layout::Component>>& components,
-              const layout::Dimensions& availableSpace) override {
+  void layout(std::vector<Component*>& components, const layout::Dimensions& availableSpace) override {
     (void)components;
     (void)availableSpace;
   }


### PR DESCRIPTION
## Summary
This PR updates all layout managers to work directly with `bombfork::prong::Component` instead of the stub `layout::Component` class, completing issue #10 as part of the scene-based architecture implementation.

## Changes Made

### Core Refactoring
- **Removed** stub `layout::Component` class from `layout_manager.h`
- **Removed** `ComponentAdapter` layer from `component.h`
- **Updated** `LayoutManager` base class to use `bombfork::prong::Component*`

### Layout Managers Updated
All 5 layout managers now use the real component system:
- ✅ **StackLayout** - Updated to use `Component*` and proper API calls
- ✅ **FlexLayout** - Updated to use `Component*` and proper API calls
- ✅ **GridLayout** - Updated to use `Component*` and proper API calls
- ✅ **DockLayout** - Updated to use `Component*` and proper API calls
- ✅ **FlowLayout** - Updated to use `Component*` and proper API calls

### API Changes
- Changed from `std::shared_ptr<layout::Component>` to `std::vector<Component*>`
- Components call `getPreferredSize()` instead of `measure()`
- Components use 4-parameter `setBounds(x, y, w, h)` instead of `Rect`

### Ownership Model
Layout managers now work with raw pointers for layout operations while parent components maintain ownership via `unique_ptr` in parent-child relationships.

## Testing
- ✅ All library code compiles successfully
- ✅ All 4 existing tests pass (100%)
- ✅ Example application builds successfully
- ✅ IWYU and clang-format checks pass

## Files Modified
- `include/bombfork/prong/core/component.h` (simplified)
- `include/bombfork/prong/layout/layout_manager.h` (removed stub)
- `include/bombfork/prong/layout/stack_layout.h`
- `include/bombfork/prong/layout/flex_layout.h`
- `include/bombfork/prong/layout/grid_layout.h`
- `include/bombfork/prong/layout/dock_layout.h`
- `include/bombfork/prong/layout/flow_layout.h`
- `tests/test_component.cpp`

## Impact
- Net reduction of 35 lines of code
- Simpler, more maintainable architecture
- Better type safety with real component types
- Eliminates duplication between stub and real Component classes

## Related Issues
- Closes #10
- Part of #3 (Fix Layout System Integration)
- Depends on #9 (completed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)