### PR TITLE
feat: add IClipboard interface for window-agnostic clipboard operations

### DIFF
--- a/.claude/commands/take-issue.md
+++ b/.claude/commands/take-issue.md
@@ -2,9 +2,21 @@
 description: Implements an issue from the backlog
 argument-hint: [issue-id]
 ---
-you will :
-* use gh cli to read the issue #$1
-* create a branch named after the issue's id and title
-* delegate the implementation to a subagent
-* iterate with the subagent until the issue's requirements are met
-* create a pull request for the implementation
+you will, in this order:
+1. use gh cli to read the issue #$1
+2. ensure all issues required before working on this one are resolved
+  2.1 if not, suggest the first unresolved dependency issue to be worked on first and stop here.
+3. check if the issue has a size label.
+  3.1 if not, assess the complexity and add one of the following labels:
+    * 'size: xs' - Less than half a day
+    * 'size: s' - Half a day
+    * 'size: m' - One day
+    * 'size: l' - Two days (broken into subtasks)
+    * 'size: xl' - More than two days (broken into subtasks)
+4. if the size is 'l' or 'xl', check if the issue is already broken into sub-tasks.
+  4.1 if not, break the issue into smaller sub-tasks and create new github issues for each sub-task, linking them to the original issue, advise to work on the first sub-task to be worked on and stop here.
+  4.2 if yes, advise to work on the first sub-task to be worked on and stop here.
+5. if the size is 'xs', 's' or 'm', create a branch named after the issue's id and title
+6. delegate the implementation to a subagent
+7. iterate with the subagent until the issue's requirements are met
+8. create a pull request for the implementation

--- a/include/bombfork/prong/events/iclipboard.h
+++ b/include/bombfork/prong/events/iclipboard.h
@@ -1,0 +1,73 @@
+#pragma once
+
+#include <string>
+
+namespace bombfork::prong::events {
+
+/**
+ * @brief Window-agnostic clipboard interface for text operations.
+ *
+ * This interface provides a platform-independent abstraction for clipboard operations,
+ * allowing the framework to work with any windowing system (GLFW, SDL, native APIs, etc.)
+ * without direct dependencies.
+ *
+ * Implementations should handle platform-specific clipboard access and provide
+ * graceful fallbacks when clipboard operations are unavailable.
+ *
+ * @note All methods should be thread-safe if the underlying platform requires it.
+ */
+class IClipboard {
+public:
+  /**
+   * @brief Virtual destructor for proper cleanup of derived implementations.
+   */
+  virtual ~IClipboard() = default;
+
+  /**
+   * @brief Retrieve text content from the system clipboard.
+   *
+   * This method reads the current text content from the clipboard. If the clipboard
+   * is empty, contains non-text data, or clipboard access fails, an empty string
+   * should be returned.
+   *
+   * @return The text content from the clipboard, or an empty string if unavailable.
+   *
+   * @note Implementations should handle errors gracefully and never throw exceptions
+   *       from this method. Return an empty string on any failure.
+   */
+  virtual std::string getString() const = 0;
+
+  /**
+   * @brief Set text content to the system clipboard.
+   *
+   * This method writes the provided text to the system clipboard, replacing any
+   * existing content. If clipboard access fails, implementations should fail
+   * silently without throwing exceptions.
+   *
+   * @param text The text content to write to the clipboard.
+   *
+   * @note Implementations should handle errors gracefully. If the operation fails,
+   *       the method should return without throwing exceptions.
+   * @note The text parameter is passed by const reference to avoid unnecessary copies
+   *       for large strings.
+   */
+  virtual void setString(const std::string& text) = 0;
+
+  /**
+   * @brief Check if the clipboard contains text content.
+   *
+   * This method determines whether the clipboard currently contains text data
+   * that can be retrieved via getString(). It should return false if the clipboard
+   * is empty, contains non-text data, or clipboard access fails.
+   *
+   * @return true if text content is available in the clipboard, false otherwise.
+   *
+   * @note This method provides a quick way to check clipboard state without
+   *       retrieving the actual content, which may be more efficient for large
+   *       clipboard contents.
+   * @note Implementations should handle errors gracefully and return false on failure.
+   */
+  virtual bool hasText() const = 0;
+};
+
+} // namespace bombfork::prong::events


### PR DESCRIPTION
## Summary

Implements issue #24 as part of the effort to remove GLFW dependency from TextInput component (#23).

This PR introduces the `IClipboard` interface, providing a window-agnostic abstraction for clipboard operations. This allows the Prong UI framework to work with any windowing backend (GLFW, SDL, native APIs, custom implementations) without direct dependencies.

## Changes

### New File
- **`include/bombfork/prong/events/iclipboard.h`**: Pure virtual interface for clipboard operations

### Interface Methods
- `std::string getString() const` - Retrieve text from clipboard
- `void setString(const std::string& text)` - Write text to clipboard  
- `bool hasText() const` - Check if clipboard contains text

### Key Design Decisions
- **Header-only**: Pure virtual interface with no implementation
- **Zero dependencies**: No GLFW, SDL, or platform-specific includes
- **Graceful failure**: Methods should handle errors without exceptions
- **Thread-safety guidance**: Documentation notes for implementations
- **UTF-8 strings**: Uses std::string for simplicity

## Testing

- ✅ Project compiles successfully with `mise build`
- ✅ clang-format passes
- ✅ No IWYU warnings
- ✅ Git hooks pass

## Next Steps

This interface enables:
- **Issue #25**: Create IKeyboard interface
- **Issue #26**: Refactor TextInput to use these abstractions
- **Issue #27**: Implement GLFW adapters
- **Issue #28**: Add unit tests with mock implementations

## Acceptance Criteria

- [x] IClipboard interface created in `include/bombfork/prong/events/iclipboard.h`
- [x] Interface is header-only (pure virtual, no implementation)
- [x] No dependencies on GLFW, SDL, or any specific windowing library
- [x] Documentation clearly explains the abstraction
- [x] Code compiles without errors

Part of #23
Closes #24