### PR TITLE
docs: add build status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Prong UI Framework
 
+[![Build Status](https://github.com/bombfork/prong/actions/workflows/build.yml/badge.svg?branch=main)](https://github.com/bombfork/prong/actions/workflows/build.yml)
+
 **Sharp, modern C++20 UI framework from BombFork**
 
 Prong is a header-mostly, CRTP-based UI framework designed for high-performance applications requiring flexible layouts, theming support, and renderer-agnostic rendering. Built with modern C++20, it provides zero-cost abstractions while maintaining clean, expressive APIs.


### PR DESCRIPTION
## Summary

Adds a GitHub Actions build status badge to the README to provide visibility into the build status of the main branch.

## Changes

- Added build status badge at the top of README.md
- Badge shows status of the `build` workflow on the main branch
- Badge links to the Actions workflow page for detailed build information

## Badge Display

The badge will show:
- ✅ **Passing** - when the build workflow succeeds on main
- ❌ **Failing** - when the build workflow fails on main
- 🟡 **Pending** - when a build is in progress

## Preview

![Build Status Badge](https://github.com/bombfork/prong/actions/workflows/build.yml/badge.svg?branch=main)

This improves project transparency and makes it easier for contributors and users to see the current build health at a glance.