### PR TITLE
feat: add TextInput unit tests and update examples with adapters (#28)

### DIFF
--- a/examples/component_builder_example.cpp
+++ b/examples/component_builder_example.cpp
@@ -49,6 +49,13 @@ void example2_text_input() {
       .withTextChangedCallback([](const std::string& text) { std::cout << "Text changed to: " << text << std::endl; })
       .build();
 
+  // NOTE: In a real application, you would inject GLFW adapters like this:
+  //   auto adapters = examples::glfw::GLFWAdapters::create(window);
+  //   textInput->setClipboard(adapters.clipboard.get());
+  //   textInput->setKeyboard(adapters.keyboard.get());
+  // This enables copy/paste and proper keyboard handling.
+  // See examples/demo_app/scenes/demo_scene.h for a complete example.
+
   std::cout << "Created text input with placeholder: " << textInput->getPlaceholder() << std::endl;
 }
 
@@ -125,6 +132,13 @@ void example5_complex_form() {
   nameInput = std::shared_ptr<TextInput>(std::move(nameInputPtr));
   emailInput = std::shared_ptr<TextInput>(std::move(emailInputPtr));
   resultList = std::shared_ptr<ListBox>(std::move(resultListPtr));
+
+  // NOTE: In a real application with GLFW, inject adapters for both TextInputs:
+  //   auto adapters = examples::glfw::GLFWAdapters::create(window);
+  //   nameInput->setClipboard(adapters.clipboard.get());
+  //   nameInput->setKeyboard(adapters.keyboard.get());
+  //   emailInput->setClipboard(adapters.clipboard.get());
+  //   emailInput->setKeyboard(adapters.keyboard.get());
 
   // Create submit button that accesses other components
   auto submitButton = create<Button>("Submit")

--- a/examples/demo_app/scenes/demo_scene.h
+++ b/examples/demo_app/scenes/demo_scene.h
@@ -13,6 +13,7 @@
 
 #pragma once
 
+#include "../../common/glfw_adapters/glfw_adapters.h"
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/list_box.h>
@@ -44,6 +45,9 @@ private:
   Button* exitButtonPtr = nullptr;
   GLFWwindow* glfwWindow = nullptr;
   int clickCount = 0;
+
+  // GLFW adapters for TextInput (must be kept alive)
+  examples::glfw::GLFWAdapters adapters;
 
 public:
   /**
@@ -102,6 +106,9 @@ private:
     // - Main-axis positioning and spacing via FlexJustify
     // - Position calculation (no manual x,y coordinates needed)
 
+    // Create GLFW adapters for TextInput dependencies
+    adapters = examples::glfw::GLFWAdapters::create(glfwWindow);
+
     // Text Input - height for line height, width stretched by layout
     auto textInput =
       create<TextInput>()
@@ -110,6 +117,10 @@ private:
         .withTextChangedCallback([](const std::string& text) { std::cout << "Text changed: " << text << std::endl; })
         .build();
     textInputPtr = textInput.get();
+
+    // Inject GLFW adapters into TextInput for clipboard and keyboard support
+    textInput->setClipboard(adapters.clipboard.get());
+    textInput->setKeyboard(adapters.keyboard.get());
 
     // Buttons - TODO: should calculate size from text + padding automatically
     auto addButton = create<Button>("Add Item")

--- a/tests/mocks/mock_clipboard.h
+++ b/tests/mocks/mock_clipboard.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <bombfork/prong/events/iclipboard.h>
+
+#include <string>
+
+namespace bombfork::prong::tests {
+
+/**
+ * @brief Mock clipboard implementation for testing
+ *
+ * This mock provides a simple in-memory clipboard for unit tests,
+ * allowing tests to verify copy/paste operations without requiring
+ * a real windowing system.
+ */
+class MockClipboard : public events::IClipboard {
+private:
+  std::string content;
+
+public:
+  /**
+   * @brief Retrieve text content from the mock clipboard
+   * @return The current clipboard content
+   */
+  std::string getString() const override { return content; }
+
+  /**
+   * @brief Set text content to the mock clipboard
+   * @param text The text to store in the clipboard
+   */
+  void setString(const std::string& text) override { content = text; }
+
+  /**
+   * @brief Check if the clipboard contains text
+   * @return true if clipboard is not empty, false otherwise
+   */
+  bool hasText() const override { return !content.empty(); }
+
+  /**
+   * @brief Clear the clipboard (test utility)
+   */
+  void clear() { content.clear(); }
+};
+
+} // namespace bombfork::prong::tests

--- a/tests/mocks/mock_keyboard.h
+++ b/tests/mocks/mock_keyboard.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <bombfork/prong/events/ikeyboard.h>
+
+namespace bombfork::prong::tests {
+
+/**
+ * @brief Mock keyboard implementation for testing
+ *
+ * This mock provides a simple 1:1 mapping between platform keys
+ * and Prong keys for unit tests, allowing tests to verify keyboard
+ * interactions without requiring a real windowing system.
+ */
+class MockKeyboard : public events::IKeyboard {
+public:
+  /**
+   * @brief Convert platform-specific key code to Prong key code
+   *
+   * In this mock, we use a simple 1:1 mapping where the platform key
+   * is cast directly to the Prong Key enum. This works for tests where
+   * we control the input values.
+   *
+   * @param platformKey Platform-specific key code (in tests, use static_cast<int>(Key))
+   * @return Prong Key enum value
+   */
+  events::Key toProngKey(int platformKey) const override { return static_cast<events::Key>(platformKey); }
+
+  /**
+   * @brief Convert Prong key code to platform-specific key code
+   *
+   * In this mock, we use a simple 1:1 mapping where the Prong key
+   * is cast directly to an integer.
+   *
+   * @param key Prong Key enum value
+   * @return Platform-specific key code
+   */
+  int fromProngKey(events::Key key) const override { return static_cast<int>(key); }
+};
+
+} // namespace bombfork::prong::tests

--- a/tests/test_text_input.cpp
+++ b/tests/test_text_input.cpp
@@ -1,0 +1,483 @@
+#include "mocks/mock_clipboard.h"
+#include "mocks/mock_keyboard.h"
+#include <bombfork/prong/components/text_input.h>
+#include <bombfork/prong/events/ikeyboard.h>
+#include <bombfork/prong/theming/color.h>
+
+#include <cassert>
+#include <cctype>
+#include <cstdint>
+#include <exception>
+#include <iostream>
+#include <string>
+
+using namespace bombfork::prong;
+using namespace bombfork::prong::tests;
+
+// Helper function to simulate key press
+void simulateKey(TextInput& input, events::Key key, bool shift = false, bool ctrl = false) {
+  uint8_t mods = 0;
+  if (shift)
+    mods |= static_cast<uint8_t>(events::KeyModifier::SHIFT);
+  if (ctrl)
+    mods |= static_cast<uint8_t>(events::KeyModifier::CONTROL);
+
+  int platformKey = static_cast<int>(key);
+  int action = static_cast<int>(events::KeyAction::PRESS);
+  input.handleKey(platformKey, action, mods);
+}
+
+// Helper function to simulate character input
+void simulateChar(TextInput& input, char c) {
+  input.handleChar(static_cast<unsigned int>(c));
+}
+
+// Helper function to simulate text input
+void simulateText(TextInput& input, const std::string& text) {
+  for (char c : text) {
+    simulateChar(input, c);
+  }
+}
+
+void test_text_input_and_retrieval() {
+  std::cout << "Testing text input and retrieval..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // Test setText and getText
+  input.setText("Hello World");
+  assert(input.getText() == "Hello World");
+
+  // Test clear
+  input.clear();
+  assert(input.getText().empty());
+
+  // Test character input
+  simulateChar(input, 'A');
+  simulateChar(input, 'B');
+  simulateChar(input, 'C');
+  assert(input.getText() == "ABC");
+
+  std::cout << "✓ Text input and retrieval tests passed" << std::endl;
+}
+
+void test_copy_to_clipboard() {
+  std::cout << "Testing copy to clipboard..." << std::endl;
+
+  TextInput input;
+  MockClipboard clipboard;
+  MockKeyboard keyboard;
+  input.setClipboard(&clipboard);
+  input.setKeyboard(&keyboard);
+
+  // Set text and select all
+  input.setText("Copy Me");
+  input.selectAll();
+  assert(input.hasSelection());
+  assert(input.getSelectedText() == "Copy Me");
+
+  // Copy to clipboard (Ctrl+C)
+  simulateKey(input, events::Key::C, false, true);
+  assert(clipboard.getString() == "Copy Me");
+
+  std::cout << "✓ Copy to clipboard tests passed" << std::endl;
+}
+
+void test_paste_from_clipboard() {
+  std::cout << "Testing paste from clipboard..." << std::endl;
+
+  TextInput input;
+  MockClipboard clipboard;
+  MockKeyboard keyboard;
+  input.setClipboard(&clipboard);
+  input.setKeyboard(&keyboard);
+
+  // Put text in clipboard
+  clipboard.setString("Pasted Text");
+  assert(clipboard.hasText());
+
+  // Paste from clipboard (Ctrl+V)
+  simulateKey(input, events::Key::V, false, true);
+  assert(input.getText() == "Pasted Text");
+
+  // Paste should replace selection
+  input.selectAll();
+  clipboard.setString("New");
+  simulateKey(input, events::Key::V, false, true);
+  assert(input.getText() == "New");
+
+  std::cout << "✓ Paste from clipboard tests passed" << std::endl;
+}
+
+void test_text_editing_operations() {
+  std::cout << "Testing text editing operations..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // Test basic insertion
+  simulateText(input, "Hello");
+  assert(input.getText() == "Hello");
+  assert(input.getCursorPosition() == 5);
+
+  // Test backspace
+  simulateKey(input, events::Key::BACKSPACE);
+  assert(input.getText() == "Hell");
+  assert(input.getCursorPosition() == 4);
+
+  // Test delete at end (should do nothing)
+  simulateKey(input, events::Key::DELETE);
+  assert(input.getText() == "Hell");
+
+  // Move cursor to middle and delete
+  input.setCursorPosition(2);
+  simulateKey(input, events::Key::DELETE);
+  assert(input.getText() == "Hel");
+  assert(input.getCursorPosition() == 2);
+
+  // Test backspace in middle
+  simulateKey(input, events::Key::BACKSPACE);
+  assert(input.getText() == "Hl");
+  assert(input.getCursorPosition() == 1);
+
+  std::cout << "✓ Text editing operations tests passed" << std::endl;
+}
+
+void test_cursor_movement() {
+  std::cout << "Testing cursor movement..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  input.setText("Hello World");
+  input.setCursorPosition(0);
+
+  // Test right arrow
+  simulateKey(input, events::Key::RIGHT);
+  assert(input.getCursorPosition() == 1);
+
+  // Test left arrow
+  simulateKey(input, events::Key::LEFT);
+  assert(input.getCursorPosition() == 0);
+
+  // Test Home key
+  input.setCursorPosition(5);
+  simulateKey(input, events::Key::HOME);
+  assert(input.getCursorPosition() == 0);
+
+  // Test End key
+  simulateKey(input, events::Key::END);
+  assert(input.getCursorPosition() == 11);
+
+  std::cout << "✓ Cursor movement tests passed" << std::endl;
+}
+
+void test_selection_handling() {
+  std::cout << "Testing selection handling..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  input.setText("Hello World");
+  input.setCursorPosition(0);
+
+  // Test select all (Ctrl+A)
+  simulateKey(input, events::Key::A, false, true);
+  assert(input.hasSelection());
+  assert(input.getSelectedText() == "Hello World");
+
+  // Clear selection
+  input.clearSelection();
+  assert(!input.hasSelection());
+
+  // Test shift+arrow selection
+  input.setCursorPosition(0);
+  simulateKey(input, events::Key::RIGHT, true, false); // Shift+Right
+  assert(input.hasSelection());
+  assert(input.getSelectedText() == "H");
+
+  simulateKey(input, events::Key::RIGHT, true, false); // Another Shift+Right
+  assert(input.getSelectedText() == "He");
+
+  // Test shift+home selection
+  input.setCursorPosition(5);
+  simulateKey(input, events::Key::HOME, true, false); // Shift+Home
+  assert(input.hasSelection());
+  assert(input.getSelectedText() == "Hello");
+
+  // Test shift+end selection
+  input.clearSelection();
+  input.setCursorPosition(0);
+  simulateKey(input, events::Key::END, true, false); // Shift+End
+  assert(input.hasSelection());
+  assert(input.getSelectedText() == "Hello World");
+
+  // Test typing replaces selection
+  input.selectAll();
+  simulateText(input, "New");
+  assert(input.getText() == "New");
+  assert(!input.hasSelection());
+
+  std::cout << "✓ Selection handling tests passed" << std::endl;
+}
+
+void test_placeholder_behavior() {
+  std::cout << "Testing placeholder behavior..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // Test placeholder
+  input.setPlaceholder("Enter text here...");
+  assert(input.getPlaceholder() == "Enter text here...");
+
+  // When text is empty, placeholder should be shown (visually, we can't test rendering)
+  assert(input.getText().empty());
+
+  // When text is added, text should be shown instead of placeholder
+  simulateText(input, "Some text");
+  assert(input.getText() == "Some text");
+
+  // Clear should show placeholder again
+  input.clear();
+  assert(input.getText().empty());
+
+  std::cout << "✓ Placeholder behavior tests passed" << std::endl;
+}
+
+void test_validation_callbacks() {
+  std::cout << "Testing validation callbacks..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // Set validator that only allows alphanumeric
+  bool validationCalled = false;
+  input.setValidator([&validationCalled](const std::string& text) {
+    validationCalled = true;
+    for (char c : text) {
+      if (!std::isalnum(c))
+        return false;
+    }
+    return true;
+  });
+
+  // Try to set valid text
+  input.setText("ValidText123");
+  assert(validationCalled);
+  assert(input.getText() == "ValidText123");
+
+  // Try to set invalid text (with space)
+  validationCalled = false;
+  input.setText("Invalid Text");
+  assert(validationCalled);
+  assert(input.getText() == "ValidText123"); // Should not change
+
+  // Test text change callback
+  std::string lastText;
+  input.setOnTextChanged([&lastText](const std::string& text) { lastText = text; });
+
+  input.setText("NewText");
+  assert(lastText == "NewText");
+
+  std::cout << "✓ Validation callbacks tests passed" << std::endl;
+}
+
+void test_max_length_enforcement() {
+  std::cout << "Testing max length enforcement..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // Set max length
+  input.setMaxLength(5);
+  assert(input.getMaxLength() == 5);
+
+  // Try to set text within limit
+  input.setText("Hello");
+  assert(input.getText() == "Hello");
+
+  // Try to set text exceeding limit
+  input.setText("Hello World");
+  assert(input.getText() == "Hello"); // Should not change
+
+  // Try to type beyond limit
+  input.clear();
+  simulateText(input, "12345");
+  assert(input.getText() == "12345");
+
+  // Additional character should not be added
+  simulateChar(input, '6');
+  assert(input.getText() == "12345"); // Still only 5 characters
+
+  std::cout << "✓ Max length enforcement tests passed" << std::endl;
+}
+
+void test_cut_operation() {
+  std::cout << "Testing cut operation..." << std::endl;
+
+  TextInput input;
+  MockClipboard clipboard;
+  MockKeyboard keyboard;
+  input.setClipboard(&clipboard);
+  input.setKeyboard(&keyboard);
+
+  // Set text and select part of it
+  input.setText("Hello World");
+  input.setCursorPosition(0);
+  simulateKey(input, events::Key::RIGHT, true, false); // Select "H"
+  simulateKey(input, events::Key::RIGHT, true, false); // Select "He"
+  simulateKey(input, events::Key::RIGHT, true, false); // Select "Hel"
+  simulateKey(input, events::Key::RIGHT, true, false); // Select "Hell"
+  simulateKey(input, events::Key::RIGHT, true, false); // Select "Hello"
+
+  assert(input.hasSelection());
+  assert(input.getSelectedText() == "Hello");
+
+  // Cut (Ctrl+X)
+  simulateKey(input, events::Key::X, false, true);
+  assert(clipboard.getString() == "Hello");
+  assert(input.getText() == " World");
+  assert(!input.hasSelection());
+
+  std::cout << "✓ Cut operation tests passed" << std::endl;
+}
+
+void test_focus_management() {
+  std::cout << "Testing focus management..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // TextInput should be able to receive focus
+  assert(input.canReceiveFocus());
+
+  // Simulate click to gain focus
+  input.handleMousePress(5, 5, 0); // Left mouse button
+  input.requestFocus();            // In real usage, EventDispatcher would call this
+
+  // When disabled, should not receive focus
+  input.setEnabled(false);
+  assert(!input.canReceiveFocus());
+
+  input.setEnabled(true);
+  assert(input.canReceiveFocus());
+
+  std::cout << "✓ Focus management tests passed" << std::endl;
+}
+
+void test_mouse_selection() {
+  std::cout << "Testing mouse selection..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+  input.setSize(200, 30);
+  input.setPosition(10, 10);
+
+  input.setText("Hello World");
+
+  // Simulate mouse press
+  input.handleMousePress(15, 15, 0);
+  assert(!input.hasSelection());
+
+  // Note: Full mouse selection testing would require accurate text measurement,
+  // which depends on the renderer implementation. We're testing the basic mechanism.
+
+  std::cout << "✓ Mouse selection tests passed" << std::endl;
+}
+
+void test_empty_operations() {
+  std::cout << "Testing operations on empty input..." << std::endl;
+
+  TextInput input;
+  MockClipboard clipboard;
+  MockKeyboard keyboard;
+  input.setClipboard(&clipboard);
+  input.setKeyboard(&keyboard);
+
+  // Test backspace on empty input
+  simulateKey(input, events::Key::BACKSPACE);
+  assert(input.getText().empty());
+
+  // Test delete on empty input
+  simulateKey(input, events::Key::DELETE);
+  assert(input.getText().empty());
+
+  // Test copy with no selection
+  clipboard.setString("existing");
+  simulateKey(input, events::Key::C, false, true);
+  assert(clipboard.getString() == "existing"); // Should not change
+
+  // Test paste into empty input
+  clipboard.setString("New Text");
+  simulateKey(input, events::Key::V, false, true);
+  assert(input.getText() == "New Text");
+
+  std::cout << "✓ Empty operations tests passed" << std::endl;
+}
+
+void test_style_management() {
+  std::cout << "Testing style management..." << std::endl;
+
+  TextInput input;
+  MockKeyboard keyboard;
+  input.setKeyboard(&keyboard);
+
+  // Test default style
+  const auto& defaultStyle = input.getStyle();
+  assert(defaultStyle.fontSize == 14);
+
+  // Test custom style
+  TextInput::Style customStyle;
+  customStyle.fontSize = 18;
+  customStyle.backgroundColor = theming::Color::WHITE();
+  customStyle.textColor = theming::Color::BLACK();
+
+  input.setStyle(customStyle);
+  const auto& retrievedStyle = input.getStyle();
+  assert(retrievedStyle.fontSize == 18);
+
+  std::cout << "✓ Style management tests passed" << std::endl;
+}
+
+int main() {
+  try {
+    std::cout << "Running TextInput tests..." << std::endl;
+    std::cout << "============================\n" << std::endl;
+
+    test_text_input_and_retrieval();
+    test_copy_to_clipboard();
+    test_paste_from_clipboard();
+    test_text_editing_operations();
+    test_cursor_movement();
+    test_selection_handling();
+    test_placeholder_behavior();
+    test_validation_callbacks();
+    test_max_length_enforcement();
+    test_cut_operation();
+    test_focus_management();
+    test_mouse_selection();
+    test_empty_operations();
+    test_style_management();
+
+    std::cout << "\n=============================" << std::endl;
+    std::cout << "✓ All TextInput tests passed!" << std::endl;
+    return 0;
+  } catch (const std::exception& e) {
+    std::cerr << "Test failed with exception: " << e.what() << std::endl;
+    return 1;
+  } catch (...) {
+    std::cerr << "Test failed with unknown exception" << std::endl;
+    return 1;
+  }
+}


### PR DESCRIPTION
## Summary

This PR completes issue #28 by adding comprehensive unit tests for TextInput and updating examples to use GLFW adapters. This builds on the TextInput abstraction work from #26 and #27.

**Changes:**
- ✅ Created mock implementations for IClipboard and IKeyboard in `tests/mocks/`
- ✅ Added comprehensive TextInput unit tests (483 lines, 14 test functions)
- ✅ Updated demo_app to properly inject GLFW adapters
- ✅ Added documentation comments to component_builder_example
- ✅ Updated CLAUDE.md with Platform Abstractions documentation

## Test Coverage

The new `test_text_input.cpp` includes tests for:
- Text input and retrieval
- Copy/paste operations with clipboard
- Text editing (backspace, delete, insertion)
- Cursor movement (arrows, Home, End)
- Selection handling (Ctrl+A, Shift+arrows)
- Placeholder behavior
- Validation callbacks
- Max length enforcement
- Cut operation (Ctrl+X)
- Focus management
- Mouse selection
- Edge cases and empty operations
- Style management

## Test Results

```
Test project /home/atom/projects/bombfork/prong/build
    Start 1: ColorTest
1/6 Test #1: ColorTest ........................   Passed    0.00 sec
    Start 2: ComponentTest
2/6 Test #2: ComponentTest ....................   Passed    0.00 sec
    Start 3: ComponentBuilderTest
3/6 Test #3: ComponentBuilderTest .............   Passed    0.00 sec
    Start 4: CoordinateSystemTest
4/6 Test #4: CoordinateSystemTest .............   Passed    0.00 sec
    Start 5: SceneTest
5/6 Test #5: SceneTest ........................   Passed    0.00 sec
    Start 6: TextInputTest
6/6 Test #6: TextInputTest ....................   Passed    0.00 sec

100% tests passed, 0 tests failed out of 6
```

## Documentation

Updated CLAUDE.md with:
- New "Platform Abstractions" section
- IClipboard and IKeyboard usage examples
- GLFW integration example
- Unit testing with mocks example
- Adapter lifetime management guidance

## Dependencies

- Depends on #26: TextInput refactored ✅ (merged)
- Depends on #27: GLFW adapters implemented ✅ (merged)

Closes #28