### PR TITLE
feat: add minimum size API to Component base class (#45)

### DIFF
--- a/include/bombfork/prong/core/component.h
+++ b/include/bombfork/prong/core/component.h
@@ -278,6 +278,18 @@ public:
    */
   virtual layout::Dimensions getPreferredSize() const { return {width, height}; }
 
+  /**
+   * @brief Get the minimum width of this component
+   * @return Minimum width in pixels (default: 0)
+   */
+  virtual int getMinimumWidth() const { return 0; }
+
+  /**
+   * @brief Get the minimum height of this component
+   * @return Minimum height in pixels (default: 0)
+   */
+  virtual int getMinimumHeight() const { return 0; }
+
   // === Event Handling ===
 
   virtual bool handleClick(int localX, int localY) {


### PR DESCRIPTION
## Summary
- Adds `getMinimumWidth()` virtual method to Component base class
- Adds `getMinimumHeight()` virtual method to Component base class
- Both methods have default implementations returning 0
- Enables components to report minimum size based on content
- Allows layout managers to respect component constraints

## Related Issues
- Closes #45
- Part of #43 - Implement automatic layout with content-aware sizing

## Changes
Added two virtual methods to `include/bombfork/prong/core/component.h`:
```cpp
virtual int getMinimumWidth() const { return 0; }
virtual int getMinimumHeight() const { return 0; }
```

## Testing
- ✅ All unit tests pass (6/6 test suites)
- ✅ Project builds without errors or warnings
- ✅ Code formatted with clang-format

## Test plan
- [x] Code compiles successfully
- [x] All existing tests pass
- [x] Methods are virtual and can be overridden
- [x] Default implementations return 0
- [x] Code follows project style guidelines