### PR TITLE
docs: update examples to document relative coordinate system (#68)

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -135,10 +135,36 @@ To create a renderer for a different graphics API (Vulkan, DirectX, etc.):
 1. Inherit from `IRenderer`
 2. Create a custom `TextureHandle` subclass for your API
 3. Implement all pure virtual methods
-4. Handle coordinate system conversions (Prong uses top-left origin)
+4. Handle coordinate system conversions (Prong uses top-left origin with relative child coordinates)
 5. Implement batching for optimal performance
 
 See `simple_opengl_renderer.h` for a complete example.
+
+### Coordinate System
+
+Prong uses a relative coordinate system:
+- **Screen origin**: Top-left corner at (0, 0)
+- **Child positions**: Relative to their parent's origin, NOT the screen
+- **Rendering**: Components use global (screen-space) coordinates internally for rendering
+- **API**: `setPosition()` and `setBounds()` use parent-relative coordinates
+- **Conversion**: Use `getGlobalPosition()` to convert local to screen coordinates
+
+Example:
+```cpp
+// Panel at screen position (100, 100)
+auto panel = create<Panel<>>()
+               .withPosition(100, 100)  // Screen position (if no parent)
+               .withSize(400, 300)
+               .build();
+
+// Button at position (10, 10) relative to panel
+// Will be rendered at screen position (110, 110)
+auto button = create<Button>("OK")
+                .withPosition(10, 10)  // Relative to parent panel
+                .withSize(100, 30)
+                .build();
+panel->addChild(std::move(button));
+```
 
 ## Integration with Existing Projects
 

--- a/examples/component_builder_example.cpp
+++ b/examples/component_builder_example.cpp
@@ -22,13 +22,17 @@ using namespace bombfork::prong;
 
 /**
  * Example 1: Creating a simple button with callback
+ *
+ * Note: withPosition() sets the position relative to the parent component.
+ * If this button is added as a child to another component, (10, 10) means
+ * 10 pixels from the parent's origin, not the screen origin.
  */
 void example1_simple_button() {
   std::cout << "\n=== Example 1: Simple Button ===" << std::endl;
 
   auto button = create<Button>("Click Me")
                   .withSize(120, 40)
-                  .withPosition(10, 10)
+                  .withPosition(10, 10) // Position relative to parent
                   .withClickCallback([]() { std::cout << "Button clicked!" << std::endl; })
                   .build();
 
@@ -81,27 +85,32 @@ void example3_list_box() {
 
 /**
  * Example 4: Creating a panel with nested children
+ *
+ * Important: Child components use coordinates relative to their parent.
+ * In this example, the buttons at positions (10, 250) and (120, 250) are
+ * relative to the panel's origin, NOT the screen. So if the panel is at
+ * screen position (10, 10), the OK button will be at screen position (20, 260).
  */
 void example4_nested_panel() {
   std::cout << "\n=== Example 4: Nested Panel ===" << std::endl;
 
-  // Create child buttons
+  // Create child buttons with positions relative to the panel
   auto okButton = create<Button>("OK")
                     .withSize(100, 30)
-                    .withPosition(10, 250)
+                    .withPosition(10, 250) // Relative to panel origin
                     .withClickCallback([]() { std::cout << "OK clicked!" << std::endl; })
                     .build();
 
   auto cancelButton = create<Button>("Cancel")
                         .withSize(100, 30)
-                        .withPosition(120, 250)
+                        .withPosition(120, 250) // Relative to panel origin
                         .withClickCallback([]() { std::cout << "Cancel clicked!" << std::endl; })
                         .build();
 
   // Create panel with children
   auto panel = create<Panel<>>()
                  .withSize(400, 300)
-                 .withPosition(10, 10)
+                 .withPosition(10, 10) // Position relative to screen (if no parent)
                  .withChildren(std::move(okButton), std::move(cancelButton))
                  .build();
 


### PR DESCRIPTION
## Summary
Updates example applications and documentation to reflect the new relative coordinate system introduced in #65, #66, and #67. This ensures developers understand that child components use positions relative to their parent, not absolute screen coordinates.

## Changes Made
- **Enhanced `examples/README.md`** with comprehensive coordinate system documentation:
  - Explanation of screen origin (top-left at 0,0)
  - Child positioning semantics (relative to parent)
  - Rendering behavior (uses global screen-space coordinates internally)
  - API details (`setPosition()` and `setBounds()` use parent-relative coordinates)
  - Conversion methods (`getGlobalPosition()` for local to screen conversion)
  - Complete code example showing a panel with a child button and the resulting screen positions

- **Updated `examples/component_builder_example.cpp`** with clarifying comments:
  - Added documentation explaining that `withPosition()` sets positions relative to the parent component
  - Enhanced Example 1 with a note about relative positioning
  - Enhanced Example 4 with detailed explanation of how nested component coordinates work
  - Added inline comments clarifying that child positions are relative to their parent

## Verification
- ✅ All examples compile successfully
- ✅ All 11 unit tests pass (100% success rate)
- ✅ Code quality checks (clang-format) passed
- ✅ Demo app executable built successfully

## Files Modified
- `examples/README.md` - Added coordinate system documentation section
- `examples/component_builder_example.cpp` - Added clarifying comments about relative coordinates

## Files Verified as Compatible
- `examples/demo_app/main.cpp`
- `examples/demo_app/scenes/demo_scene.h`
- All adapter files in `examples/adapters/` and `examples/common/glfw_adapters/`

## Related Issues
Closes #68
Part of the coordinate system refactoring series (#62, #65, #66, #67)

## Test Plan
- [x] Build examples with `mise build-examples`
- [x] Run unit tests
- [x] Verify all examples compile without errors
- [x] Code quality checks passed