### PR TITLE
Add markdown linting and pre-push build validation to git hooks

### DIFF
--- a/.claude/commands/take-issue.md
+++ b/.claude/commands/take-issue.md
@@ -3,22 +3,27 @@ description: Implements an issue from the backlog
 argument-hint: [issue-id]
 ---
 you will, in this order:
+
 1. use gh cli to read the issue #$1.
 2. ensure all issues required before working on this one are resolved.
+
   2.1 if not, suggest the first unresolved dependency issue to be worked on first and stop here.
-3. check if the issue has a size label.
+
+1. check if the issue has a size label.
+
   3.1 if not, assess the complexity and add one of the following labels:
-    * 'size: xs' - Less than half a day
-    * 'size: s' - Half a day
-    * 'size: m' - One day
-    * 'size: l' - Two days (broken into subtasks)
-    * 'size: xl' - More than two days (broken into subtasks)
-4. if the size is 'l' or 'xl', check if the issue is already broken into sub-tasks.
+* 'size: xs' - Less than half a day
+* 'size: s' - Half a day
+* 'size: m' - One day
+* 'size: l' - Two days (broken into subtasks)
+* 'size: xl' - More than two days (broken into subtasks)
+1. if the size is 'l' or 'xl', check if the issue is already broken into sub-tasks.
   4.1 if not, break the issue into smaller sub-tasks and create new github issues for each sub-task, linking them to the original issue, advise to work on the first sub-task to be worked on and stop here.
   4.2 if yes, check each sub taks has its own github issue.
     4.2.1 if not, create the missing github sub task issues and stop here.
     4.2.2 if yes, advise to work on the first sub-task to be worked on and stop here.
-5. if the size is 'xs', 's' or 'm', create a branch named after the issue's id and title.
-6. delegate the implementation to a subagent.
-7. iterate with the subagent until the issue's requirements are met.
-8. create a pull request for the implementation.
+
+2. if the size is 'xs', 's' or 'm', create a branch named after the issue's id and title.
+3. delegate the implementation to a subagent.
+4. iterate with the subagent until the issue's requirements are met.
+5. create a pull request for the implementation.

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
 cmake = "3.28.6"
+"github:rvben/rumdl" = "latest"
 hk = "1.18.3"
 ninja = "1.13.1"
 pkl = "0.29.1"
@@ -143,6 +144,20 @@ description = "Run clang-format fix"
 depends = ["check-deps"]
 run = """
 clang-format -i
+"""
+
+[tasks.markdown-check]
+description = "Check markdown files for linting issues"
+depends = ["check-deps"]
+run = """
+rumdl check
+"""
+
+[tasks.markdown-fix]
+description = "Auto-fix markdown linting issues"
+depends = ["check-deps"]
+run = """
+rumdl fmt
 """
 
 [tasks.demo]

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Prong is a modern C++20 UI framework from BombFork designed for high-performance applications. It's header-mostly, uses CRTP (Curiously Recurring Template Pattern) for zero-cost abstractions, and is both renderer-agnostic and window-agnostic.
 
 **Key Design Principles:**
+
 - Header-mostly architecture (minimal implementation files)
 - CRTP-based component system for compile-time polymorphism
 - Zero dependencies for core functionality
@@ -16,6 +17,7 @@ Prong is a modern C++20 UI framework from BombFork designed for high-performance
 ## Build Commands
 
 ### Standard Build
+
 ```bash
 mkdir build && cd build
 cmake .. -DPRONG_BUILD_EXAMPLES=ON -DPRONG_BUILD_TESTS=ON
@@ -23,10 +25,12 @@ cmake --build .
 ```
 
 ### Build Options
+
 - `PRONG_BUILD_EXAMPLES` - Build example applications (default: ON)
 - `PRONG_BUILD_TESTS` - Build unit tests (default: ON)
 
 ### Installation
+
 ```bash
 sudo cmake --install .
 ```
@@ -56,6 +60,7 @@ This eliminates virtual function call overhead while maintaining clean abstracti
 ### Component System
 
 The `Component` class (`include/bombfork/prong/core/component.h`) is the foundation:
+
 - **Parent/child relationships**: Components form a tree structure with automatic ownership via `std::unique_ptr`
 - **Event propagation**: Events flow down from parent to children, with children handling first (topmost rendered components get priority)
 - **Coordinate systems**: Uses a relative coordinate system with caching - see detailed section below
@@ -66,6 +71,7 @@ The `Component` class (`include/bombfork/prong/core/component.h`) is the foundat
 ### Coordinate System
 
 Prong uses a **relative coordinate system** where child positions are always relative to their parent's origin. This design provides several benefits:
+
 - **Intuitive positioning**: Child components don't need to know their parent's position
 - **Automatic updates**: Moving a parent automatically moves all children
 - **Layout flexibility**: Layout managers work with local coordinates only
@@ -160,6 +166,7 @@ The `Component::handleEvent()` method automatically converts global screen coord
 #### Cache Invalidation
 
 The global coordinate cache is automatically invalidated when:
+
 - A component's position changes via `setPosition()` or `setBounds()`
 - A component is added to a new parent
 - Cache invalidation automatically cascades to all descendants
@@ -177,6 +184,7 @@ You should never need to manually invalidate the cache.
 ### Renderer Abstraction
 
 The `IRenderer` interface (`include/bombfork/prong/rendering/irenderer.h`) provides:
+
 - Frame lifecycle: `beginFrame()`, `endFrame()`, `present()`
 - Drawing primitives: `drawRect()`, `drawSprite()`, `drawText()`
 - Batching support: `drawSprites()` for efficient multi-sprite rendering
@@ -187,6 +195,7 @@ All rendering must go through the `IRenderer` interface. Components receive rend
 ### Event System
 
 Prong uses a **hierarchical event propagation model** where events flow through the component tree:
+
 - **Event handling**: Components override `handleEventSelf()` to respond to events
 - **Automatic propagation**: Events propagate from parent to children automatically via `Component::handleEvent()`
 - **Hit testing**: Uses `Component::containsEvent()` for positional event checking
@@ -203,6 +212,7 @@ Components can specify how they respond to parent resize events through resize b
 #### Unified Resize Behavior
 
 The `ResizeBehavior` enum provides unified control over both axes:
+
 - `FIXED`: Keep original size and position (default)
 - `SCALE`: Scale proportionally with parent
 - `FILL`: Fill available parent space
@@ -215,6 +225,7 @@ component->setResizeBehavior(Component::ResizeBehavior::FILL);
 #### Per-Axis Resize Behavior
 
 For more control, use `AxisResizeBehavior` to set independent horizontal and vertical behavior:
+
 - `AxisResizeBehavior::FIXED`: Keep original size on this axis
 - `AxisResizeBehavior::SCALE`: Scale proportionally with parent on this axis
 - `AxisResizeBehavior::FILL`: Fill available parent space on this axis
@@ -226,10 +237,12 @@ panel->setAxisResizeBehavior(Component::AxisResizeBehavior::FIXED,
 ```
 
 **Important**: When using FlexLayout, per-axis behavior is usually preferred:
+
 - For horizontal FlexLayout (ROW): Use `FIXED` or `SCALE` horizontally (let FlexLayout control width), `FILL` vertically
 - For vertical FlexLayout (COLUMN): Use `FILL` horizontally, `FIXED` or `SCALE` vertically (let FlexLayout control height)
 
 Example from demo app:
+
 ```cpp
 // Left panel in horizontal FlexLayout: fixed width (200px), fills height
 leftPanel->setAxisResizeBehavior(Component::AxisResizeBehavior::FIXED,
@@ -243,6 +256,7 @@ centerPanel->setAxisResizeBehavior(Component::AxisResizeBehavior::FILL,
 #### Responsive Constraints
 
 Combine resize behavior with constraints for bounded resizing:
+
 ```cpp
 Component::ResponsiveConstraints constraints;
 constraints.minWidth = 200;
@@ -255,6 +269,7 @@ component->setConstraints(constraints);
 ### Layout System
 
 Layout managers (`include/bombfork/prong/layout/`) use CRTP and provide:
+
 - **FlexLayout**: Flexbox-inspired with direction, justify, align, gap, and grow/shrink factors
 - **GridLayout**: CSS Grid-inspired with rows/columns and gaps
 - **DockLayout**: Docking panels (top, bottom, left, right, center fill)
@@ -262,12 +277,14 @@ Layout managers (`include/bombfork/prong/layout/`) use CRTP and provide:
 - **FlowLayout**: Automatic wrapping layout
 
 Layout managers implement:
+
 - `measureLayout()`: Calculate required space for components
 - `layout()`: Position and size components within available space
 
 ### Theming System
 
 Located in `include/bombfork/prong/theming/`:
+
 - **ThemeManager**: Singleton managing global themes, thread-safe
 - **Color**: RGBA color with utility methods and named constants
 
@@ -276,6 +293,7 @@ Themes use semantic color names.
 ## Implementation Files
 
 Only these modules require `.cpp` files (all in `src/`):
+
 - `core/coordinate_system.cpp` - World ↔ Screen transformations
 - `core/async_callback_queue.cpp` - Thread-safe callback management
 - `theming/theme_manager.cpp` - Global theme state
@@ -285,6 +303,7 @@ All UI components (Button, Panel, ListBox, TextInput, Dialog, Toolbar, Viewport)
 ## Namespace Structure
 
 All code lives under `bombfork::prong` with subnamespaces:
+
 - `bombfork::prong::core` - Component base classes
 - `bombfork::prong::components` - All UI widgets (Button, Panel, ListBox, TextInput, Dialog, Toolbar, Viewport)
 - `bombfork::prong::layout` - Layout managers
@@ -300,10 +319,12 @@ All code lives under `bombfork::prong` with subnamespaces:
 The `TextInput` component requires two platform-specific interfaces for full functionality:
 
 **IClipboard** (`include/bombfork/prong/events/iclipboard.h`):
+
 - Provides clipboard access for copy/paste operations
 - Must be injected via `textInput->setClipboard(clipboard)`
 
 **IKeyboard** (`include/bombfork/prong/events/ikeyboard.h`):
+
 - Converts platform-specific key codes to Prong's agnostic `Key` enum
 - Must be injected via `textInput->setKeyboard(keyboard)`
 
@@ -355,6 +376,7 @@ The mock implementations provide simple in-memory storage for testing without re
 ## C++20 Features
 
 The codebase requires C++20 and uses:
+
 - Concepts for template constraints
 - Ranges for algorithms
 - Three-way comparison operator (spaceship)
@@ -366,6 +388,7 @@ GCC 10+, Clang 13+, or MSVC 2019+ required.
 ## CMake Integration
 
 When used as a library via FetchContent:
+
 ```cmake
 FetchContent_Declare(prong
     GIT_REPOSITORY https://github.com/bombfork/prong.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ mise build
 ```
 
 This command:
+
 - Configures CMake with Ninja generator
 - Builds the core library
 - Builds all tests
@@ -129,6 +130,7 @@ This builds and executes all unit tests. All tests must pass before submitting a
 Header dependencies are verified automatically by IWYU and is integrated to cmake and git hooks.
 
 IWYU ensures that:
+
 - Headers only include what they directly use
 - No transitive include dependencies
 - Header files are self-contained
@@ -138,6 +140,7 @@ The git hooks will automatically check this before commits.
 ### Demo Application Testing
 
 The demo app (`examples/demo_app/`) is used for:
+
 - UX testing and validation
 - Manual feature testing
 - Gathering user feedback
@@ -160,6 +163,7 @@ Prong follows a **header-only architecture** where possible. Only add `.cpp` imp
 - Platform-specific code requiring conditional compilation
 
 **Existing `.cpp` files:**
+
 - `src/core/coordinate_system.cpp` - World ↔ Screen transformations
 - `src/core/async_callback_queue.cpp` - Thread-safe callback management
 - `src/theming/theme_manager.cpp` - Global theme state
@@ -193,6 +197,7 @@ class LayoutManager {
 Prong uses a **relative coordinate system** where child positions are always relative to their parent:
 
 **DO:**
+
 ```cpp
 // Position children relative to parent
 panel->setPosition(100, 50);        // Panel at (100, 50) in parent space
@@ -201,6 +206,7 @@ panel->addChild(std::move(button)); // Button now at global (120, 60)
 ```
 
 **DON'T:**
+
 ```cpp
 // Never use global coordinates when positioning children
 int globalX, globalY;
@@ -209,6 +215,7 @@ button->setPosition(globalX + 20, globalY + 10);  // WRONG!
 ```
 
 **Rendering:**
+
 - Use `getGlobalX()` and `getGlobalY()` in `render()` methods
 - Global coordinates are cached automatically
 - Never manually track or store global positions
@@ -376,6 +383,7 @@ mise demo
 ### 4. Commit
 
 Git hooks will automatically:
+
 - Run clang-format on changed files
 - Run iwyu checks
 - Validate commit message format
@@ -405,6 +413,7 @@ Then create a Pull Request on GitHub with:
 **Title:** Clear, concise description of changes
 
 **Description should include:**
+
 - Summary of changes
 - Motivation and context
 - Related issue numbers (e.g., "Fixes #123", "Closes #456")
@@ -413,6 +422,7 @@ Then create a Pull Request on GitHub with:
 - Any breaking changes
 
 **Example PR description:**
+
 ```markdown
 ## Summary
 Add responsive resize behavior to Panel component to support dynamic layouts.
@@ -449,6 +459,7 @@ Prong uses [hk](https://github.com/jdx/hk) to manage git hooks. The configuratio
 ### Pre-commit Hook
 
 The pre-commit hook automatically:
+
 - Runs `clang-format` on all staged C++ files (`**/*.cpp`, `**/*.h`)
 - Checks formatting with `mise run format-check`
 - Automatically fixes formatting issues with `mise run format` when `fix = true`

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ For detailed information, see [docs/coordinate_system.md](docs/coordinate_system
 
 ### Core Components
 
-```
+```text
 bombfork::prong::
 ├── core/                   # Base component system
 │   ├── Scene              # Root scene component (entry point for UI hierarchy)
@@ -315,6 +315,7 @@ void mouseButtonCallback(GLFWwindow* w, int btn, int action, int mods) {
 ```
 
 **Key Features:**
+
 - Scene is the entry point for all events from the window system
 - Events automatically propagate to children with coordinate conversion
 - Children rendered last (topmost) receive events first

--- a/docs/api/QUICK_REFERENCE.md
+++ b/docs/api/QUICK_REFERENCE.md
@@ -5,7 +5,9 @@ Condensed reference for all Prong APIs. See individual files for detailed docume
 ## Core Classes
 
 ### Component
+
 Base class for all UI elements.
+
 ```cpp
 class Component {
   virtual void update(double deltaTime) = 0;
@@ -19,7 +21,9 @@ class Component {
 ```
 
 ### Scene
+
 Root container and event coordinator.
+
 ```cpp
 class Scene : public Component {
   Scene(IWindow* window, IRenderer* renderer);
@@ -30,7 +34,9 @@ class Scene : public Component {
 ```
 
 ### ComponentBuilder
+
 Fluent API for component construction.
+
 ```cpp
 auto component = create<ComponentType>(/* constructor args */)
                    .withSize(width, height)
@@ -40,7 +46,9 @@ auto component = create<ComponentType>(/* constructor args */)
 ```
 
 ### Event
+
 Unified event structure.
+
 ```cpp
 struct Event {
   enum class Type { MOUSE_PRESS, MOUSE_RELEASE, MOUSE_MOVE, MOUSE_SCROLL, KEY_PRESS, KEY_RELEASE, CHAR_INPUT };
@@ -56,6 +64,7 @@ struct Event {
 ## UI Components
 
 ### Button
+
 ```cpp
 auto button = create<Button>("Label")
                 .withSize(200, 60)
@@ -64,6 +73,7 @@ auto button = create<Button>("Label")
 ```
 
 ### Panel
+
 ```cpp
 auto panel = create<Panel>()
                .withSize(400, 300)
@@ -72,6 +82,7 @@ auto panel = create<Panel>()
 ```
 
 ### TextInput
+
 ```cpp
 auto input = create<TextInput>()
                .withPlaceholder("Enter text...")
@@ -82,6 +93,7 @@ input->setKeyboard(keyboardPtr);    // Required for key handling
 ```
 
 ### ListBox
+
 ```cpp
 auto listBox = create<ListBox>()
                  .withSize(300, 400)
@@ -92,6 +104,7 @@ listBox->addItem("Item 2");
 ```
 
 ### Dialog
+
 ```cpp
 auto dialog = Dialog::create(renderer, "Title", "Message", DialogType::OK_CANCEL);
 dialog->setButtonCallback([](Dialog::Result result) {
@@ -100,6 +113,7 @@ dialog->setButtonCallback([](Dialog::Result result) {
 ```
 
 ### Toolbar
+
 ```cpp
 auto toolbar = create<Toolbar>()
                  .withSize(800, 50)
@@ -109,6 +123,7 @@ toolbar->addItem("Edit", []() { /* Edit clicked */ });
 ```
 
 ### Viewport
+
 ```cpp
 auto viewport = create<Viewport>()
                   .withSize(600, 400)
@@ -120,7 +135,9 @@ auto viewport = create<Viewport>()
 ## Layout Managers
 
 ### FlexLayout
+
 Flexbox-inspired layout.
+
 ```cpp
 auto layout = std::make_unique<FlexLayout<ParentType>>();
 layout->setDirection(FlexLayout<ParentType>::Direction::ROW);  // or COLUMN
@@ -134,7 +151,9 @@ layout->setItemProperties(childPtr, {.grow = 1.0f, .shrink = 1.0f});
 ```
 
 ### GridLayout
+
 CSS Grid-inspired layout.
+
 ```cpp
 auto layout = std::make_unique<GridLayout<ParentType>>();
 layout->setRows(3);
@@ -144,7 +163,9 @@ panel->setLayoutManager(std::move(layout));
 ```
 
 ### DockLayout
+
 Docking panel layout.
+
 ```cpp
 auto layout = std::make_unique<DockLayout<ParentType>>();
 layout->setGaps(5, 5, 5, 5);  // top, bottom, left, right
@@ -158,7 +179,9 @@ layout->setItemProperties(centerPanel, {.position = DockPosition::CENTER});
 Dock positions: `TOP`, `BOTTOM`, `LEFT`, `RIGHT`, `CENTER`
 
 ### StackLayout
+
 Simple sequential layout.
+
 ```cpp
 auto layout = std::make_unique<StackLayout<ParentType>>();
 layout->setOrientation(StackLayout<ParentType>::Orientation::VERTICAL);  // or HORIZONTAL
@@ -167,7 +190,9 @@ panel->setLayoutManager(std::move(layout));
 ```
 
 ### FlowLayout
+
 Wrapping flow layout.
+
 ```cpp
 auto layout = std::make_unique<FlowLayout<ParentType>>();
 layout->setOrientation(FlowLayout<ParentType>::Orientation::HORIZONTAL);
@@ -179,6 +204,7 @@ panel->setLayoutManager(std::move(layout));
 ## Event Handling
 
 ### Custom Event Handler
+
 ```cpp
 class MyComponent : public Component {
 protected:
@@ -210,6 +236,7 @@ protected:
 ```
 
 ### Focus Management
+
 ```cpp
 component->requestFocus();  // Request focus
 
@@ -221,6 +248,7 @@ if (component->getFocusState() == Component::FocusState::FOCUSED) {
 ## Rendering
 
 ### IRenderer Interface
+
 ```cpp
 class IRenderer {
   virtual bool beginFrame() = 0;
@@ -241,6 +269,7 @@ class IRenderer {
 ```
 
 ### Custom Renderer Example
+
 ```cpp
 class MyRenderer : public IRenderer {
   bool beginFrame() override {
@@ -263,7 +292,9 @@ class MyRenderer : public IRenderer {
 ## Theming
 
 ### ThemeManager
+
 Singleton for global theme management.
+
 ```cpp
 // Get instance
 auto& theme = ThemeManager::getInstance();
@@ -284,6 +315,7 @@ theme.setThemeChangeCallback([]() {
 Color roles: `BACKGROUND`, `TEXT`, `BUTTON_BACKGROUND`, `BUTTON_BACKGROUND_HOVER`, `BUTTON_BACKGROUND_PRESSED`, `BUTTON_TEXT`, `PANEL_BACKGROUND`, `INPUT_BACKGROUND`, `INPUT_TEXT`, etc.
 
 ### Color
+
 ```cpp
 Color color(0.5f, 0.8f, 0.3f, 1.0f);  // RGBA [0.0, 1.0]
 color.setRGB(r, g, b);
@@ -295,6 +327,7 @@ color.getRGBA(r, g, b, a);
 ## Window Abstraction
 
 ### IWindow
+
 ```cpp
 class IWindow {
   virtual bool shouldClose() const = 0;
@@ -306,6 +339,7 @@ class IWindow {
 ```
 
 ### IClipboard (for TextInput)
+
 ```cpp
 class IClipboard {
   virtual std::string getString() = 0;
@@ -314,6 +348,7 @@ class IClipboard {
 ```
 
 ### IKeyboard (for TextInput)
+
 ```cpp
 class IKeyboard {
   virtual Key mapPlatformKey(int platformKey) = 0;
@@ -325,6 +360,7 @@ Platform-agnostic Key enum: `A`-`Z`, `SPACE`, `ENTER`, `BACKSPACE`, `DELETE`, `L
 ## Resize Behavior
 
 ### Unified Behavior
+
 ```cpp
 component->setResizeBehavior(Component::ResizeBehavior::FIXED);   // Keep original size
 component->setResizeBehavior(Component::ResizeBehavior::SCALE);   // Scale proportionally
@@ -333,6 +369,7 @@ component->setResizeBehavior(Component::ResizeBehavior::MAINTAIN_ASPECT);  // Sc
 ```
 
 ### Per-Axis Behavior
+
 ```cpp
 component->setAxisResizeBehavior(
   Component::AxisResizeBehavior::FIXED,  // Horizontal
@@ -341,6 +378,7 @@ component->setAxisResizeBehavior(
 ```
 
 ### Constraints
+
 ```cpp
 Component::ResponsiveConstraints constraints;
 constraints.minWidth = 200;
@@ -353,6 +391,7 @@ component->setConstraints(constraints);
 ## Custom Components and Layouts
 
 ### Custom Component
+
 ```cpp
 class ColorPicker : public Component {
 public:
@@ -377,6 +416,7 @@ protected:
 ```
 
 ### Custom Layout Manager
+
 ```cpp
 template<typename ParentT>
 class CircularLayout : public LayoutManager<CircularLayout<ParentT>> {
@@ -401,6 +441,7 @@ class CircularLayout : public LayoutManager<CircularLayout<ParentT>> {
 ## Common Patterns
 
 ### Application Structure
+
 ```cpp
 int main() {
   // 1. Initialize window system
@@ -450,6 +491,7 @@ int main() {
 ```
 
 ### Three-Panel Layout
+
 ```cpp
 auto root = create<Panel>().withSize(1200, 800).build();
 auto layout = std::make_unique<FlexLayout<Panel>>();
@@ -471,6 +513,7 @@ root->addChild(std::move(right));
 ```
 
 ### Dynamic UI
+
 ```cpp
 // Add components
 parent->addChild(createNewComponent());

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -5,12 +5,14 @@ Comprehensive API documentation for the Prong UI framework.
 ## Quick Navigation
 
 ### Core
+
 - [Component](core/Component.md) - Base class for all UI elements
 - [Scene](core/Scene.md) - Root container and event coordinator
 - [ComponentBuilder](core/ComponentBuilder.md) - Fluent API for component construction
 - [Event](core/Event.md) - Unified event structure
 
 ### Components
+
 - [Button](components/Button.md) - Clickable button widget
 - [Panel](components/Panel.md) - Container panel
 - [TextInput](components/TextInput.md) - Single-line text input
@@ -20,6 +22,7 @@ Comprehensive API documentation for the Prong UI framework.
 - [Viewport](components/Viewport.md) - Scrollable viewport container
 
 ### Layout Managers
+
 - [FlexLayout](layouts/FlexLayout.md) - Flexbox-inspired flexible layout
 - [GridLayout](layouts/GridLayout.md) - CSS Grid-inspired grid layout
 - [DockLayout](layouts/DockLayout.md) - Docking panel layout (top, bottom, left, right, center)
@@ -27,15 +30,18 @@ Comprehensive API documentation for the Prong UI framework.
 - [FlowLayout](layouts/FlowLayout.md) - Wrapping flow layout
 
 ### Events
+
 - [Event Struct](events/Event.md) - Event data structure
 - [IWindow](events/IWindow.md) - Window abstraction interface
 - [IClipboard](events/IClipboard.md) - Clipboard abstraction
 - [IKeyboard](events/IKeyboard.md) - Keyboard key mapping
 
 ### Rendering
+
 - [IRenderer](rendering/IRenderer.md) - Renderer abstraction interface
 
 ### Theming
+
 - [ThemeManager](theming/ThemeManager.md) - Global theme management
 - [Color](theming/Color.md) - RGBA color utility class
 - [AdvancedTheme](theming/AdvancedTheme.md) - Theme data structure
@@ -44,7 +50,7 @@ Comprehensive API documentation for the Prong UI framework.
 
 ### Component Hierarchy
 
-```
+```text
 Component (abstract base)
 ├── Panel (container)
 ├── Button (interactive)
@@ -58,6 +64,7 @@ Component (abstract base)
 ### Coordinate Systems
 
 Prong uses a **relative coordinate system**:
+
 - **Local coordinates**: Position relative to parent (used for positioning children)
 - **Global coordinates**: Absolute screen-space position (used for rendering and hit testing)
 - Coordinates are automatically cached and invalidated as needed
@@ -65,6 +72,7 @@ Prong uses a **relative coordinate system**:
 ### Event Propagation
 
 Events flow hierarchically:
+
 1. Scene receives event from window
 2. Scene propagates to root components
 3. Components check bounds and propagate to children
@@ -74,6 +82,7 @@ Events flow hierarchically:
 ### Layout System
 
 Layout managers use CRTP for zero-overhead polymorphism:
+
 ```cpp
 template<typename ParentT>
 class MyLayout : public LayoutManager<MyLayout<ParentT>> {
@@ -155,6 +164,7 @@ component->setConstraints(constraints);
 ## Examples
 
 Each API page includes usage examples. For complete working examples, see:
+
 - `examples/basic/` - Simple focused examples
 - `examples/intermediate/` - Complex composition patterns
 - `examples/advanced/` - Custom components, layouts, and optimization
@@ -197,6 +207,7 @@ while (!windowAdapter->shouldClose()) {
 ## Platform Integration
 
 Prong is platform-agnostic. You need to provide:
+
 - **Window adapter** (IWindow): GLFW, SDL, or native
 - **Renderer** (IRenderer): OpenGL, Vulkan, or custom
 - **Optional**: IClipboard, IKeyboard for TextInput

--- a/docs/api/core/Component.md
+++ b/docs/api/core/Component.md
@@ -125,6 +125,7 @@ protected:
 ### Event Handling
 
 Override `handleEventSelf()` in derived classes:
+
 ```cpp
 bool handleEventSelf(const Event& event) override {
   if (event.type == Event::Type::MOUSE_PRESS) {
@@ -140,11 +141,13 @@ Events are in **local coordinates** relative to this component.
 ### Resize Behavior
 
 **Unified (both axes same)**:
+
 ```cpp
 component->setResizeBehavior(Component::ResizeBehavior::FILL);
 ```
 
 **Per-axis (independent control)**:
+
 ```cpp
 component->setAxisResizeBehavior(
   Component::AxisResizeBehavior::FIXED,
@@ -153,6 +156,7 @@ component->setAxisResizeBehavior(
 ```
 
 **With constraints**:
+
 ```cpp
 Component::ResponsiveConstraints constraints;
 constraints.minWidth = 200;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -5,6 +5,7 @@
 Prong is a modern C++20 UI framework designed for high-performance applications with minimal overhead. It employs a scene-based architecture with a component hierarchy system, CRTP-based polymorphism, and platform abstraction layers for maximum flexibility.
 
 **Core Design Principles:**
+
 - **Header-mostly architecture**: Minimal implementation files, most functionality in headers
 - **Zero-cost abstractions**: CRTP eliminates virtual function overhead
 - **Platform agnostic**: Renderer and window abstractions work with any backend
@@ -13,7 +14,7 @@ Prong is a modern C++20 UI framework designed for high-performance applications 
 
 ## System Architecture
 
-```
+```text
 ┌─────────────────────────────────────────────────────────────┐
 │                        Application                          │
 └────────────────────────┬────────────────────────────────────┘
@@ -52,6 +53,7 @@ Prong is a modern C++20 UI framework designed for high-performance applications 
 The `Scene` class is the top-level container that manages the entire UI hierarchy. It serves as the bridge between your application window and the component tree.
 
 **Responsibilities:**
+
 - Owns references to window and renderer interfaces
 - Automatically fills window dimensions
 - Handles window resize events and propagates them to children
@@ -105,6 +107,7 @@ scene.detach();
 The `Component` class is the foundation for all UI elements. It provides essential functionality for rendering, events, geometry management, and parent-child relationships.
 
 **Key Features:**
+
 - **Pure virtual methods**: `update()` and `render()` must be implemented by concrete components
 - **Parent-child tree**: Components form a hierarchy with automatic ownership via `std::unique_ptr`
 - **Relative coordinates**: Local positioning with automatic global coordinate caching
@@ -114,7 +117,7 @@ The `Component` class is the foundation for all UI elements. It provides essenti
 
 **Component Tree Structure:**
 
-```
+```text
 Scene (root)
 ├─ Panel (FlexLayout, horizontal)
 │  ├─ Button "File"
@@ -130,6 +133,7 @@ Scene (root)
 ```
 
 Each component:
+
 - Has a local position relative to its parent
 - Can have zero or more children
 - Receives events in reverse rendering order (topmost first)
@@ -175,19 +179,21 @@ public:
 ```
 
 **Benefits:**
+
 - **Zero overhead**: No virtual function table lookups
 - **Compile-time optimization**: Inlining and dead code elimination
 - **Type safety**: Compile-time type checking
 - **Clean interface**: Similar to traditional inheritance
 
 **Where CRTP is Used:**
+
 - Layout managers (`LayoutManager<DerivedT>`)
 - Template-based component extensions
 - Compile-time behavior customization
 
 ### Component Lifecycle
 
-```
+```text
 ┌──────────────┐
 │   Creation   │  - Constructor initializes state
 │              │  - Renderer passed (or inherited from parent)
@@ -237,12 +243,14 @@ Prong uses a **relative coordinate system** with automatic caching for optimal p
 ### Coordinate Spaces
 
 **Local Coordinates (Relative):**
+
 - Position relative to parent's origin
 - Used for positioning children and layout calculations
 - Set via `setPosition(x, y)` or `setBounds(x, y, w, h)`
 - For root components (no parent), local coordinates ARE global coordinates
 
 **Global Coordinates (Absolute):**
+
 - Absolute screen-space position
 - Calculated by walking up parent chain and summing local positions
 - Cached for performance, automatically invalidated on position changes
@@ -251,7 +259,7 @@ Prong uses a **relative coordinate system** with automatic caching for optimal p
 
 ### Caching System
 
-```
+```text
 Component Position Change
          │
          ▼
@@ -285,6 +293,7 @@ Component Position Change
 ```
 
 **Performance Characteristics:**
+
 - Cache hit: O(1) - return cached values
 - Cache miss (single component): O(1) - calculate from parent's cache
 - Cache miss (entire tree): O(depth) - walk to root once
@@ -381,7 +390,7 @@ Prong uses a **hierarchical event propagation model** where events flow naturall
 
 ### Event Flow
 
-```
+```text
 Window Event
      │
      ▼
@@ -416,17 +425,20 @@ Window Event
 ### Event Types
 
 **Mouse Events:**
+
 - `MOUSE_PRESS` - Mouse button pressed
 - `MOUSE_RELEASE` - Mouse button released
 - `MOUSE_MOVE` - Mouse cursor moved
 - `MOUSE_SCROLL` - Mouse wheel scrolled
 
 **Keyboard Events:**
+
 - `KEY_PRESS` - Key pressed
 - `KEY_RELEASE` - Key released
 - `CHAR_INPUT` - Character input (for text entry)
 
 **Window Events:**
+
 - `WINDOW_RESIZE` - Window size changed
 - `WINDOW_FOCUS` - Window gained/lost focus
 
@@ -456,6 +468,7 @@ protected:
 ```
 
 **Key Points:**
+
 - Event coordinates are automatically converted to local space during propagation
 - Return `true` to stop propagation (event consumed)
 - Return `false` to allow event to continue to other components
@@ -514,7 +527,7 @@ enum class FocusState {
 
 ### Focus Flow
 
-```
+```text
 User Interaction
        │
        ▼
@@ -536,6 +549,7 @@ User Interaction
 ```
 
 **Focus Behavior:**
+
 - Only one component can have keyboard focus at a time
 - Scene manages focus globally via `setFocusedComponent()`
 - Components can subscribe to focus changes via `setFocusCallback()`
@@ -559,6 +573,7 @@ public:
 ```
 
 Implementations available:
+
 - GLFW (`GLFWWindowAdapter` in examples)
 - SDL (community implementations)
 - Native OS APIs (Windows, macOS, Linux)
@@ -568,6 +583,7 @@ Implementations available:
 Some components require additional platform abstractions:
 
 **IClipboard** - For copy/paste operations:
+
 ```cpp
 class IClipboard {
 public:
@@ -577,6 +593,7 @@ public:
 ```
 
 **IKeyboard** - For key code translation:
+
 ```cpp
 class IKeyboard {
 public:
@@ -600,7 +617,7 @@ textInput->setKeyboard(keyboard);
 
 All code lives under `bombfork::prong` with logical subnamespaces:
 
-```
+```text
 bombfork::prong
 ├── core               - Component, Scene, Event
 ├── components         - Button, Panel, ListBox, TextInput, Dialog, Toolbar, Viewport
@@ -645,10 +662,12 @@ auto panel = create<Panel<>>()
 ## Threading Model
 
 **Single-threaded by default:**
+
 - Component tree, event handling, rendering are single-threaded
 - Main thread owns the UI hierarchy
 
 **Thread-safe components:**
+
 - `ThemeManager` - Thread-safe singleton for global theme access
 - `AsyncCallbackQueue` - Thread-safe callback queue for async operations
 
@@ -690,6 +709,7 @@ target_link_libraries(myapp PRIVATE bombfork::prong)
 ```
 
 **Build Options:**
+
 - `PRONG_BUILD_EXAMPLES` - Build example applications (default: ON)
 - `PRONG_BUILD_TESTS` - Build unit tests (default: ON)
 
@@ -698,16 +718,19 @@ target_link_libraries(myapp PRIVATE bombfork::prong)
 ### Header-Mostly Architecture
 
 Only these modules require `.cpp` implementation files:
+
 - `core/coordinate_system.cpp` - World ↔ Screen transformations
 - `core/async_callback_queue.cpp` - Thread-safe callback management
 - `theming/theme_manager.cpp` - Global theme state
 
 All UI components are fully header-only:
+
 - `Button`, `Panel`, `ListBox`, `TextInput`, `Dialog`, `Toolbar`, `Viewport`
 - All layout managers
 - Component base class
 
 **Benefits:**
+
 - Faster compilation (no need to recompile library)
 - Better optimization (compiler sees full implementation)
 - Easier integration (just include headers)
@@ -715,6 +738,7 @@ All UI components are fully header-only:
 ### C++20 Features
 
 The codebase requires C++20 and uses:
+
 - **Concepts** - Template constraints for type safety
 - **Ranges** - Modern iteration and algorithms
 - **Three-way comparison** (spaceship operator `<=>`)
@@ -722,6 +746,7 @@ The codebase requires C++20 and uses:
 - **constexpr improvements** - More compile-time computation
 
 **Compiler Requirements:**
+
 - GCC 10+
 - Clang 13+
 - MSVC 2019 16.11+

--- a/docs/best_practices.md
+++ b/docs/best_practices.md
@@ -11,6 +11,7 @@ This guide provides practical guidelines for building effective, maintainable, a
 Always use `Scene` as the top-level container for your UI hierarchy. Don't create standalone component trees without a scene.
 
 **Good:**
+
 ```cpp
 Scene scene(window, renderer);
 scene.attach();
@@ -27,6 +28,7 @@ while (!window->shouldClose()) {
 ```
 
 **Bad:**
+
 ```cpp
 // Don't manage component trees without Scene
 auto mainPanel = create<Panel<>>(renderer).build();
@@ -125,6 +127,7 @@ public:
 ### When to Use Each Layout
 
 **FlexLayout** - Use for:
+
 - Toolbars and navigation bars
 - Button groups with flexible spacing
 - Responsive lists that adapt to container size
@@ -132,6 +135,7 @@ public:
 - Components that need grow/shrink behavior
 
 **GridLayout** - Use for:
+
 - Icon grids and image galleries
 - Form layouts with labels and inputs
 - Calculator-style button grids
@@ -139,18 +143,21 @@ public:
 - Any regular grid structure
 
 **DockLayout** - Use for:
+
 - Application main windows (IDE-style)
 - Dashboards with fixed panels
 - Resizable side panels
 - Top/bottom toolbars with center content
 
 **StackLayout** - Use for:
+
 - Simple vertical menus
 - Stacked cards or panels
 - Linear lists with consistent spacing
 - When you just need simple stacking (simpler than FlexLayout)
 
 **FlowLayout** - Use for:
+
 - Tag clouds
 - Wrapping button groups
 - Image galleries with automatic wrapping
@@ -158,7 +165,7 @@ public:
 
 ### Layout Decision Tree
 
-```
+```text
 Need multiple regions (top/bottom/sides)?
 ├─ Yes → DockLayout
 └─ No
@@ -208,6 +215,7 @@ panel->addChild(std::move(cancelBtn));
 The builder pattern provides cleaner code and better defaults:
 
 **Good:**
+
 ```cpp
 auto button = create<Button>("Submit")
     .withSize(100, 40)
@@ -217,6 +225,7 @@ auto button = create<Button>("Submit")
 ```
 
 **Acceptable (when you need more control):**
+
 ```cpp
 auto button = std::make_unique<Button>(renderer, "Submit");
 button->setSize(100, 40);
@@ -371,6 +380,7 @@ toolbar->addChild(ui::createSecondaryButton("Cancel"));
 When positioning children, use local coordinates relative to parent:
 
 **Good:**
+
 ```cpp
 void MyPanel::layoutChildren() {
     // Position relative to this panel's origin
@@ -380,6 +390,7 @@ void MyPanel::layoutChildren() {
 ```
 
 **Bad:**
+
 ```cpp
 void MyPanel::layoutChildren() {
     int globalX = getGlobalX();
@@ -394,6 +405,7 @@ void MyPanel::layoutChildren() {
 In `render()` methods, always use global coordinates:
 
 **Good:**
+
 ```cpp
 void MyComponent::render() override {
     int x = getGlobalX();  // Screen-space X
@@ -405,6 +417,7 @@ void MyComponent::render() override {
 ```
 
 **Bad:**
+
 ```cpp
 void MyComponent::render() override {
     // Don't use localX/localY for rendering!
@@ -417,6 +430,7 @@ void MyComponent::render() override {
 Global coordinates can become stale. Always compute on-demand:
 
 **Bad:**
+
 ```cpp
 class MyComponent : public Component {
     int storedGlobalX, storedGlobalY;  // Will become stale!
@@ -433,6 +447,7 @@ class MyComponent : public Component {
 ```
 
 **Good:**
+
 ```cpp
 class MyComponent : public Component {
     void render() override {
@@ -449,6 +464,7 @@ class MyComponent : public Component {
 Don't manually position children if you're using a layout manager:
 
 **Bad:**
+
 ```cpp
 auto panel = create<Panel<FlexLayout>>().build();
 panel->getLayout().configure({...});
@@ -461,6 +477,7 @@ panel->addChild(std::move(btn));
 ```
 
 **Good:**
+
 ```cpp
 auto panel = create<Panel<FlexLayout>>().build();
 panel->getLayout().configure({...});
@@ -912,6 +929,7 @@ layout->configure({
 ### Don't Mix Manual and Layout Positioning
 
 **Problem:**
+
 ```cpp
 auto panel = create<Panel<FlexLayout>>().build();
 auto btn = create<Button>("Click")
@@ -921,6 +939,7 @@ panel->addChild(std::move(btn));
 ```
 
 **Solution:** Choose one or the other:
+
 ```cpp
 // Either use layout
 auto panel = create<Panel<FlexLayout>>().build();
@@ -938,6 +957,7 @@ panel->addChild(std::move(btn));
 ### Don't Forget to Attach Scene
 
 **Problem:**
+
 ```cpp
 Scene scene(window, renderer);
 // scene.attach() not called!
@@ -949,6 +969,7 @@ while (!window->shouldClose()) {
 ```
 
 **Solution:**
+
 ```cpp
 Scene scene(window, renderer);
 scene.attach();  // Always attach!
@@ -964,6 +985,7 @@ scene.detach();  // Clean shutdown
 ### Don't Forget Platform Adapters for TextInput
 
 **Problem:**
+
 ```cpp
 auto textInput = create<TextInput>().build();
 // No clipboard or keyboard set!
@@ -971,6 +993,7 @@ auto textInput = create<TextInput>().build();
 ```
 
 **Solution:**
+
 ```cpp
 auto adapters = GLFWAdapters::create(window);
 auto textInput = create<TextInput>().build();
@@ -982,6 +1005,7 @@ textInput->setKeyboard(adapters.keyboard.get());
 ### Don't Use Raw Pointers for Ownership
 
 **Problem:**
+
 ```cpp
 Component* button = new Button(renderer, "Click");
 panel->addChild(???);  // Can't transfer ownership
@@ -989,6 +1013,7 @@ panel->addChild(???);  // Can't transfer ownership
 ```
 
 **Solution:**
+
 ```cpp
 auto button = std::make_unique<Button>(renderer, "Click");
 panel->addChild(std::move(button));  // Proper ownership transfer
@@ -997,6 +1022,7 @@ panel->addChild(std::move(button));  // Proper ownership transfer
 ### Don't Ignore Const Correctness in Event Handlers
 
 **Problem:**
+
 ```cpp
 bool handleEventSelf(const Event& event) override {
     event.mouseX = 100;  // Compile error: event is const!
@@ -1005,6 +1031,7 @@ bool handleEventSelf(const Event& event) override {
 ```
 
 **Solution:**
+
 ```cpp
 bool handleEventSelf(const Event& event) override {
     int localX = event.mouseX;  // Copy if you need to modify

--- a/docs/component_builder.md
+++ b/docs/component_builder.md
@@ -37,6 +37,7 @@ auto button = create<Button>("Click Me")
 Two factory functions are provided:
 
 ### `create<ComponentT>()`
+
 Creates a component using its default constructor.
 
 ```cpp
@@ -46,6 +47,7 @@ auto button = create<Button>()
 ```
 
 ### `create<ComponentT>(args...)`
+
 Creates a component by forwarding arguments to its constructor.
 
 ```cpp
@@ -59,6 +61,7 @@ auto button = create<Button>("OK")  // Passes "OK" to Button constructor
 All component types support these methods:
 
 ### Position and Size
+
 ```cpp
 builder.withPosition(int x, int y)
 builder.withSize(int width, int height)
@@ -66,6 +69,7 @@ builder.withBounds(int x, int y, int width, int height)
 ```
 
 ### State
+
 ```cpp
 builder.withVisible(bool visible)
 builder.withEnabled(bool enabled)
@@ -73,16 +77,19 @@ builder.withDebugName(const std::string& name)
 ```
 
 ### Callbacks
+
 ```cpp
 builder.withFocusCallback(Component::FocusCallback callback)
 ```
 
 ### Layout
+
 ```cpp
 builder.withLayout(std::shared_ptr<LayoutT> layout)
 ```
 
 ### Children
+
 ```cpp
 builder.withChild(std::unique_ptr<Component> child)
 builder.withChildren(std::unique_ptr<Component>... children)

--- a/docs/coordinate_system.md
+++ b/docs/coordinate_system.md
@@ -64,7 +64,7 @@ panel->addChild(std::move(button));
 
 For any component, its global position is:
 
-```
+```text
 globalX = localX + parent.globalX
 globalY = localY + parent.globalY
 ```
@@ -524,6 +524,7 @@ See the `CoordinateSystem` class documentation for details on world coordinate t
 **Symptoms**: Component appears at (0, 0) or wrong location
 
 **Likely causes**:
+
 1. Using local coordinates for rendering instead of global
 2. Not calling `getGlobalX()` and `getGlobalY()`
 
@@ -542,6 +543,7 @@ void render() override {
 **Symptoms**: Child stays in place when parent moves
 
 **Likely causes**:
+
 1. Child is not actually added to parent via `addChild()`
 2. Child's position is being set to global coordinates
 3. Child is being repositioned after parent moves
@@ -560,6 +562,7 @@ parent->addChild(std::move(child));  // Establish relationship
 **Symptoms**: Clicks/hover don't work at new position
 
 **Likely causes**:
+
 1. Component not added to the scene hierarchy
 2. Custom `containsEvent()` implementation using incorrect coordinate space
 
@@ -580,10 +583,12 @@ bool containsGlobal(int globalX, int globalY) const {
 **Symptoms**: Slow rendering or event handling
 
 **Likely causes**:
+
 1. Constantly invalidating cache by repeatedly calling `setPosition()`
 2. Very deep component nesting (>50 levels)
 
 **Solution**:
+
 - Only update positions when actually changed
 - Consider flattening the hierarchy if possible
 - Profile to confirm this is actually the bottleneck

--- a/docs/docker.md
+++ b/docs/docker.md
@@ -26,6 +26,7 @@ mise docker-shell
 ```
 
 All mise Docker tasks are in `mise-tasks/` and automatically handle:
+
 - Image names and tags
 - Volume mounts
 - User ID/GID mapping (prevents permission issues)
@@ -41,12 +42,14 @@ All mise Docker tasks are in `mise-tasks/` and automatically handle:
 ## Architecture
 
 Multi-stage Dockerfile:
+
 1. **toolchain**: Base Arch Linux with C++ compiler
 2. **iwyu-builder**: Builds include-what-you-use from AUR
 3. **mise-tools**: Installs mise-managed tools
 4. **builder**: Final image with all dependencies (library, tests, examples)
 
 Single unified `prong-builder` image includes:
+
 - System packages: clang-format, include-what-you-use
 - Mise tools: cmake, ninja, hk, pkl (versions in `.mise.toml`)
 - Example deps: glfw-wayland, mesa, libgl, libglvnd
@@ -112,6 +115,7 @@ docker build --no-cache -t prong-builder:latest .
 ### Tool Versions
 
 Tool versions are defined in `.mise.toml`. To update:
+
 1. Edit `.mise.toml`
 2. Rebuild: `mise docker-build`
 

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -5,6 +5,7 @@
 Prong's layout system provides automatic positioning and sizing of components within containers. Layout managers handle the complex math of arranging UI elements, allowing you to focus on the structure and behavior of your interface.
 
 **Key Features:**
+
 - **Automatic arrangement** - Components positioned automatically based on layout rules
 - **Responsive sizing** - Layouts adapt to container size changes
 - **Composable** - Nest layouts within layouts for complex UIs
@@ -33,11 +34,13 @@ public:
 ```
 
 **Measurement Phase:**
+
 - Calculate minimum space needed for all children
 - Consider preferred sizes, minimum sizes, grow/shrink factors
 - Return total dimensions required
 
 **Layout Phase:**
+
 - Position components within available space
 - Apply alignment, spacing, and distribution rules
 - Set component bounds using local coordinates
@@ -69,6 +72,7 @@ auto panel = create<Panel<>>()
 ### Layout Invalidation
 
 Layouts are recalculated when:
+
 - A child component is added or removed
 - A child's size changes
 - The container is resized
@@ -124,7 +128,8 @@ auto panel = create<Panel<>>()
 ```
 
 **Result (ROW):**
-```
+
+```text
 ┌─────────────────────────────┐
 │ ┌───┐ ┌───┐ ┌───┐          │
 │ │ A │ │ B │ │ C │          │
@@ -134,7 +139,8 @@ auto panel = create<Panel<>>()
 ```
 
 **Result (COLUMN):**
-```
+
+```text
 ┌──────┐
 │ ┌──┐ │
 │ │A │ │
@@ -167,7 +173,7 @@ enum class FlexJustify {
 
 **Visual Guide (ROW direction):**
 
-```
+```text
 START:
 ┌─────────────────────────────┐
 │ [A][B][C]                   │
@@ -215,7 +221,7 @@ enum class FlexAlign {
 
 **Visual Guide (ROW direction, varying heights):**
 
-```
+```text
 STRETCH:
 ┌────────────────┐
 │ ┌──┐ ┌──┐ ┌──┐│
@@ -288,7 +294,8 @@ auto panel = create<Panel<>>()
 ```
 
 **Result (with extra space):**
-```
+
+```text
 ┌─────────────────────────────────────┐
 │ ┌──────┐ ┌──────────────┐ ┌──────┐ │
 │ │  A   │ │      B       │ │  C   │ │
@@ -300,6 +307,7 @@ auto panel = create<Panel<>>()
 ### Common Use Cases
 
 **Toolbar:**
+
 ```cpp
 auto toolbar = create<Panel<FlexLayout>>()
     .withSize(800, 50)
@@ -318,6 +326,7 @@ toolbar->addChild(create<Button>("View").build());
 ```
 
 **Sidebar Layout:**
+
 ```cpp
 auto sidebar = create<Panel<FlexLayout>>()
     .withSize(200, 600)
@@ -336,6 +345,7 @@ sidebar->addChild(create<Button>("Help").build());
 ```
 
 **Form Row:**
+
 ```cpp
 auto formRow = create<Panel<FlexLayout>>()
     .withSize(400, 40)
@@ -404,7 +414,8 @@ auto panel = create<Panel<>>()
 ```
 
 **Result:**
-```
+
+```text
 ┌───────────────────────────┐
 │ ┌───┐  ┌───┐  ┌───┐      │
 │ │ 1 │  │ 2 │  │ 3 │      │
@@ -430,6 +441,7 @@ Forces all cells to be the same size (determined by largest component).
 ### Common Use Cases
 
 **Icon Grid:**
+
 ```cpp
 auto iconGrid = std::make_shared<GridLayout>();
 iconGrid->configure({
@@ -453,6 +465,7 @@ for (int i = 0; i < 12; i++) {
 ```
 
 **Form Grid:**
+
 ```cpp
 auto formGrid = std::make_shared<GridLayout>();
 formGrid->configure({
@@ -474,6 +487,7 @@ auto form = create<Panel<>>()
 ```
 
 **Calculator Layout:**
+
 ```cpp
 auto calcGrid = std::make_shared<GridLayout>();
 calcGrid->configure({
@@ -560,7 +574,8 @@ auto mainWindow = create<Panel<>>()
 ```
 
 **Result:**
-```
+
+```text
 ┌─────────────────────────────────┐
 │         TOP (Toolbar)           │ ← 10% height
 ├──────┬──────────────────────────┤
@@ -576,6 +591,7 @@ auto mainWindow = create<Panel<>>()
 ### Common Use Cases
 
 **IDE Layout:**
+
 ```cpp
 auto ideLayout = std::make_shared<DockLayout>();
 
@@ -623,6 +639,7 @@ ideLayout->addRegion({
 ```
 
 **Dashboard:**
+
 ```cpp
 auto dashboardLayout = std::make_shared<DockLayout>();
 
@@ -696,7 +713,8 @@ auto panel = create<Panel<>>()
 ```
 
 **Result (VERTICAL):**
-```
+
+```text
 ┌────────────┐
 │ ┌────────┐ │
 │ │Button 1│ │
@@ -715,7 +733,8 @@ auto panel = create<Panel<>>()
 ### Alignment Examples
 
 **STRETCH (vertical stack):**
-```
+
+```text
 ┌──────────────────┐
 │ ┌──────────────┐ │
 │ │   Button 1   │ │
@@ -727,7 +746,8 @@ auto panel = create<Panel<>>()
 ```
 
 **CENTER (vertical stack):**
-```
+
+```text
 ┌──────────────────┐
 │    ┌────────┐    │
 │    │Button 1│    │
@@ -741,6 +761,7 @@ auto panel = create<Panel<>>()
 ### Common Use Cases
 
 **Vertical Menu:**
+
 ```cpp
 auto menuLayout = std::make_shared<StackLayout>();
 menuLayout->configure({
@@ -761,6 +782,7 @@ auto menu = create<Panel<>>()
 ```
 
 **Horizontal Button Group:**
+
 ```cpp
 auto buttonGroup = std::make_shared<StackLayout>();
 buttonGroup->configure({
@@ -838,7 +860,8 @@ for (int i = 1; i <= 10; i++) {
 ```
 
 **Result (wraps automatically):**
-```
+
+```text
 ┌───────────────────────────────┐
 │ [1]  [2]  [3]  [4]            │
 │                               │
@@ -851,6 +874,7 @@ for (int i = 1; i <= 10; i++) {
 ### Common Use Cases
 
 **Tag Cloud:**
+
 ```cpp
 auto tagFlow = std::make_shared<FlowLayout>();
 tagFlow->configure({
@@ -877,6 +901,7 @@ for (const auto& tag : tags) {
 ```
 
 **Image Gallery:**
+
 ```cpp
 auto galleryFlow = std::make_shared<FlowLayout>();
 galleryFlow->configure({
@@ -974,7 +999,8 @@ auto mainWindow = create<Panel<>>()
 ```
 
 **Visual Structure:**
-```
+
+```text
 ┌─────────────────────────────────────────┐
 │  ┌───┐ ┌────┐ ┌────┐  (FlexLayout)     │
 │  │File│ │Edit│ │View│                   │
@@ -1106,11 +1132,13 @@ auto button = create<Button>("OK")
 **Symptom:** Components added but not showing
 
 **Causes:**
+
 - Parent size too small (0x0)
 - Components positioned outside parent bounds
 - Layout not configured properly
 
 **Solution:**
+
 ```cpp
 // Check parent size
 int w, h;
@@ -1131,10 +1159,12 @@ panel->performLayout();
 **Symptom:** Components draw on top of each other
 
 **Causes:**
+
 - No layout attached (all at 0,0)
 - Layout spacing = 0 and children same size
 
 **Solution:**
+
 ```cpp
 // Ensure layout is attached
 auto layout = std::make_shared<StackLayout>();
@@ -1149,11 +1179,13 @@ panel->setLayout(layout);
 **Symptom:** Components don't fit properly
 
 **Causes:**
+
 - Grow/shrink factors incorrect
 - Cell alignment wrong
 - Missing size constraints
 
 **Solution:**
+
 ```cpp
 // For FlexLayout, check grow factors
 layout->setItemProperties({
@@ -1172,10 +1204,12 @@ layout->configure({
 **Symptom:** Changes don't reflect visually
 
 **Causes:**
+
 - Layout invalidation not triggered
 - Layout calculations happen lazily
 
 **Solution:**
+
 ```cpp
 // Force layout recalculation
 panel->invalidateLayout();

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ This directory contains example implementations and applications demonstrating h
 
 ## Directory Structure
 
-```
+```text
 examples/
 ├── adapters/              # Example adapter implementations
 │   ├── glfw_window_adapter.h       # GLFW → IWindow adapter
@@ -29,6 +29,7 @@ Demonstrates how to implement the `IWindow` interface using GLFW. Key features:
 - Handles modifier key state tracking
 
 **Usage:**
+
 ```cpp
 GLFWwindow* glfwWindow = glfwCreateWindow(1280, 720, "App", nullptr, nullptr);
 auto windowAdapter = std::make_unique<GLFWWindowAdapter>(glfwWindow);
@@ -43,6 +44,7 @@ scene.attach();
 Demonstrates how to implement the `IRenderer` interface using OpenGL. This is a minimal implementation focusing on clarity over performance.
 
 **Features:**
+
 - Texture management with OpenGL texture objects
 - Basic primitive rendering (rectangles, sprites)
 - Orthographic 2D projection setup
@@ -50,6 +52,7 @@ Demonstrates how to implement the `IRenderer` interface using OpenGL. This is a 
 
 **Production Notes:**
 A production renderer would include:
+
 - Texture atlas management
 - Batch rendering with vertex buffers
 - Font rendering with FreeType or similar
@@ -57,6 +60,7 @@ A production renderer would include:
 - Performance optimizations
 
 **Usage:**
+
 ```cpp
 auto renderer = std::make_unique<SimpleOpenGLRenderer>();
 renderer->initialize(1280, 720);
@@ -69,11 +73,13 @@ The `demo_app` example demonstrates a comprehensive Prong application showcasing
 ### Building and Running
 
 **Using mise (recommended):**
+
 ```bash
 mise demo
 ```
 
 **Manual build:**
+
 ```bash
 mkdir build && cd build
 cmake .. -DPRONG_BUILD_EXAMPLES=ON
@@ -156,6 +162,7 @@ See `simple_opengl_renderer.h` for a complete example.
 ### Coordinate System
 
 Prong uses a relative coordinate system:
+
 - **Screen origin**: Top-left corner at (0, 0)
 - **Child positions**: Relative to their parent's origin, NOT the screen
 - **Rendering**: Components use global (screen-space) coordinates internally for rendering
@@ -163,6 +170,7 @@ Prong uses a relative coordinate system:
 - **Conversion**: Use `getGlobalPosition()` to convert local to screen coordinates
 
 Example:
+
 ```cpp
 // Panel at screen position (100, 100)
 auto panel = create<Panel<>>()
@@ -184,9 +192,11 @@ panel->addChild(std::move(button));
 If you have an existing application with a rendering system:
 
 ### Option 1: Adapter Pattern
+
 Create adapters that wrap your existing renderer and window classes (recommended for quick integration).
 
 ### Option 2: Direct Implementation
+
 Implement `IWindow` and `IRenderer` directly in your window/renderer classes.
 
 ### Example Integration Flow

--- a/examples/advanced/01_custom_component/README.md
+++ b/examples/advanced/01_custom_component/README.md
@@ -14,6 +14,7 @@ Demonstrates creating a custom ColorPicker component from scratch, showing all a
 ## ColorPicker Component
 
 A simple color picker with:
+
 - 18 color swatches in a grid
 - Click to select color
 - Visual feedback for selection

--- a/examples/advanced/04_performance/README.md
+++ b/examples/advanced/04_performance/README.md
@@ -5,21 +5,25 @@ Demonstrates performance characteristics with 100 components and optimization te
 ## Performance Features
 
 ### 1. Layout Caching
+
 - Layouts only recalculate when invalidated
 - Use `invalidateLayout()` only when necessary
 - Batch multiple changes before invalidating
 
 ### 2. Coordinate Caching
+
 - Global coordinates cached and invalidated automatically
 - Multiple `getGlobalPosition()` calls in one frame are cheap
 - Cache invalidates on position changes and cascades to children
 
 ### 3. CRTP Zero-Cost Abstraction
+
 - No virtual function overhead for layouts
 - Compile-time polymorphism
 - Templates resolve at compile time
 
 ### 4. Efficient Event Propagation
+
 - Hit testing before processing
 - Events stop at handler (don't continue unnecessarily)
 - Reverse iteration for Z-order

--- a/examples/basic/01_hello_button/README.md
+++ b/examples/basic/01_hello_button/README.md
@@ -3,6 +3,7 @@
 The absolute minimal Prong UI application - a single button in a window.
 
 ## What This Demonstrates
+
 - Basic GLFW window creation and OpenGL context setup
 - Prong renderer initialization
 - Creating a Scene (root container for UI)
@@ -19,6 +20,7 @@ The absolute minimal Prong UI application - a single button in a window.
 **Event Loop**: The standard pattern of polling events, updating components, rendering, and swapping buffers.
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples
@@ -44,7 +46,8 @@ Experiment with these modifications to learn more:
 5. **Change background**: Modify the `renderer->clear()` RGB values (line 85)
 
 **Tip**: Position is in pixels from the top-left corner (0,0). To center a button, use:
-```
+
+```text
 x = (windowWidth - buttonWidth) / 2
 y = (windowHeight - buttonHeight) / 2
 ```

--- a/examples/basic/02_stack_layout/README.md
+++ b/examples/basic/02_stack_layout/README.md
@@ -3,6 +3,7 @@
 Simple layout manager that arranges children in a vertical or horizontal stack.
 
 ## What This Demonstrates
+
 - Using Panel with StackLayout template parameter
 - Configuring vertical stacking with spacing
 - Configuring horizontal stacking with spacing
@@ -15,10 +16,12 @@ Simple layout manager that arranges children in a vertical or horizontal stack.
 **Layout Configuration**: Access the layout manager via `panel->getLayoutManager()` to configure direction and spacing. The layout automatically repositions children whenever the panel is resized or children are added/removed.
 
 **Direction**:
+
 - `VERTICAL`: Stack children top-to-bottom
 - `HORIZONTAL`: Stack children left-to-right
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples

--- a/examples/basic/03_flex_layout/README.md
+++ b/examples/basic/03_flex_layout/README.md
@@ -3,6 +3,7 @@
 Flexbox-inspired layout manager for responsive, flexible UI designs.
 
 ## What This Demonstrates
+
 - Using FlexLayout in ROW and COLUMN directions
 - Setting grow factors for flexible sizing
 - Configuring justify content (START, SPACE_BETWEEN, etc.)
@@ -16,6 +17,7 @@ Flexbox-inspired layout manager for responsive, flexible UI designs.
 **Grow Factor**: Determines how much a component grows relative to siblings. If one child has grow=1 and another has grow=2, the second child gets twice as much of the remaining space.
 
 **Justify Content**: Controls spacing along the main axis (horizontal for ROW, vertical for COLUMN)
+
 - `START`: Pack items at the start
 - `CENTER`: Center items
 - `END`: Pack items at the end
@@ -24,12 +26,14 @@ Flexbox-inspired layout manager for responsive, flexible UI designs.
 - `SPACE_EVENLY`: Distribute items with equal space
 
 **Align Items**: Controls alignment along the cross axis
+
 - `START`: Align items at the start
 - `CENTER`: Center items
 - `END`: Align items at the end
 - `STRETCH`: Stretch items to fill cross axis
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples

--- a/examples/basic/04_grid_layout/README.md
+++ b/examples/basic/04_grid_layout/README.md
@@ -3,6 +3,7 @@
 2D grid layout manager for arranging components in rows and columns.
 
 ## What This Demonstrates
+
 - Using GridLayout for 2D arrangements
 - Configuring rows and columns
 - Setting row and column gaps
@@ -18,12 +19,14 @@
 **Automatic Placement**: Children are placed automatically in grid cells, filling left-to-right, top-to-bottom. Just add children in the order you want them to appear.
 
 **Configuration**:
+
 - `setRows(n)`: Number of rows in the grid
 - `setColumns(n)`: Number of columns in the grid
 - `setRowGap(px)`: Vertical spacing between cells
 - `setColumnGap(px)`: Horizontal spacing between cells
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples
@@ -49,6 +52,7 @@ mise build-examples
 5. **Nested grids**: Create a panel with GridLayout that contains other panels with GridLayout
 
 **Common Use Cases**:
+
 - Calculator interfaces
 - Numeric keypads
 - Icon/app launchers

--- a/examples/basic/05_dock_layout/README.md
+++ b/examples/basic/05_dock_layout/README.md
@@ -3,6 +3,7 @@
 Application-style layout with panels docked to edges and a center fill area.
 
 ## What This Demonstrates
+
 - Using DockLayout for complex application interfaces
 - Docking panels to TOP, BOTTOM, LEFT, RIGHT positions
 - Center panel that fills remaining space
@@ -14,6 +15,7 @@ Application-style layout with panels docked to edges and a center fill area.
 **DockLayout**: A layout manager designed for application-style interfaces. It divides the container into 5 regions: TOP, BOTTOM, LEFT, RIGHT, and CENTER. Docked panels take fixed sizes from their edges, and the CENTER panel fills whatever space remains.
 
 **Dock Positions**:
+
 - `TOP`: Docked to top edge, spans full width, uses specified height
 - `BOTTOM`: Docked to bottom edge, spans full width, uses specified height
 - `LEFT`: Docked to left edge, spans remaining height, uses specified width
@@ -21,16 +23,19 @@ Application-style layout with panels docked to edges and a center fill area.
 - `CENTER`: Fills all remaining space after other panels are placed
 
 **Size Behavior**:
+
 - TOP/BOTTOM panels: Width is ignored (spans full width), height is used
 - LEFT/RIGHT panels: Height is ignored (spans remaining height), width is used
 - CENTER panel: Both dimensions are ignored (fills remaining space)
 
 **Docking Order**: The order you dock panels matters:
+
 1. TOP and BOTTOM panels are placed first (full width)
 2. LEFT and RIGHT panels are placed next (in remaining height)
 3. CENTER panel fills what's left
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples
@@ -62,6 +67,7 @@ mise build-examples
 5. **Toggle visibility**: Add buttons that show/hide sidebar panels dynamically
 
 **Common Use Cases**:
+
 - IDE interfaces (code editor with toolbars, sidebars, output panel)
 - Document editors (toolbar, rulers, document area, status bar)
 - Image editors (tools, canvas, properties, layers panel)

--- a/examples/basic/06_flow_layout/README.md
+++ b/examples/basic/06_flow_layout/README.md
@@ -3,6 +3,7 @@
 Automatic wrapping layout that flows children like text, wrapping to new lines as needed.
 
 ## What This Demonstrates
+
 - Using FlowLayout for tag clouds and chip lists
 - Automatic line wrapping when content doesn't fit
 - Configuring horizontal and vertical gaps
@@ -16,12 +17,14 @@ Automatic wrapping layout that flows children like text, wrapping to new lines a
 **Automatic Wrapping**: When a child component doesn't fit on the current line (based on its width + gaps), FlowLayout automatically moves it to the next line. This makes the layout highly responsive to container size changes.
 
 **Gap Configuration**:
+
 - `setHorizontalGap(px)`: Space between items on the same line
 - `setVerticalGap(px)`: Space between lines
 
 **Child Sizing**: FlowLayout respects each child's individual size - it doesn't resize children. This allows variable-width buttons to coexist naturally (like tags of different lengths).
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples
@@ -47,6 +50,7 @@ mise build-examples
 5. **Very wide container**: Make the panel wider so all tags fit on one line
 
 **Common Use Cases**:
+
 - Tag clouds (categories, labels, keywords)
 - Filter chips (active filters in a search interface)
 - Skill lists (resume, profile pages)
@@ -56,6 +60,7 @@ mise build-examples
 - Color palette swatches
 
 **Comparison with Other Layouts**:
+
 - **vs StackLayout**: StackLayout only goes in one direction, no wrapping
 - **vs FlexLayout**: FlexLayout can grow/shrink children, FlowLayout keeps original sizes
 - **vs GridLayout**: GridLayout enforces regular grid, FlowLayout allows irregular wrapping

--- a/examples/basic/07_text_input/README.md
+++ b/examples/basic/07_text_input/README.md
@@ -3,6 +3,7 @@
 Interactive text entry component with full keyboard support and copy/paste functionality.
 
 ## What This Demonstrates
+
 - Using TextInput component for user text entry
 - Setting up GLFW adapters (clipboard and keyboard)
 - Handling text change callbacks
@@ -15,10 +16,12 @@ Interactive text entry component with full keyboard support and copy/paste funct
 **TextInput**: A single-line text entry component with full text editing capabilities. Supports cursor movement, text selection, copy/paste, and standard keyboard shortcuts.
 
 **Platform Adapters**: TextInput requires two platform-specific adapters:
+
 - **IClipboard**: Provides clipboard access for copy/paste operations
 - **IKeyboard**: Converts platform key codes to Prong's agnostic Key enum
 
 **GLFW Adapters**: Prong provides reference implementations for GLFW:
+
 ```cpp
 auto adapters = glfw::GLFWAdapters::create(glfwWindow);
 textInput->setClipboard(adapters.clipboard.get());
@@ -26,6 +29,7 @@ textInput->setKeyboard(adapters.keyboard.get());
 ```
 
 **Keyboard Shortcuts**:
+
 - `Ctrl+C`: Copy selected text
 - `Ctrl+V`: Paste from clipboard
 - `Ctrl+X`: Cut selected text
@@ -36,6 +40,7 @@ textInput->setKeyboard(adapters.keyboard.get());
 - `Backspace/Delete`: Remove characters
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples
@@ -63,6 +68,7 @@ mise build-examples
 5. **Watch callbacks**: See console output as you type in each field
 
 **Form Validation Example**:
+
 ```cpp
 auto emailInput = create<TextInput>()
   .withPlaceholder("user@example.com")
@@ -74,6 +80,7 @@ auto emailInput = create<TextInput>()
 ```
 
 **Common Use Cases**:
+
 - Login forms (username, password)
 - Search boxes
 - Settings panels (name, URL, path inputs)

--- a/examples/basic/08_list_box/README.md
+++ b/examples/basic/08_list_box/README.md
@@ -3,6 +3,7 @@
 Scrollable list component with selection support and dynamic item management.
 
 ## What This Demonstrates
+
 - Using ListBox component for item lists
 - Creating ListBox with initial items
 - Handling selection callbacks
@@ -21,6 +22,7 @@ Scrollable list component with selection support and dynamic item management.
 **Selection Callback**: Register a callback with `withSelectionCallback()` to be notified when an item is selected. The callback receives both the index and the item text.
 
 **Dynamic Manipulation**:
+
 ```cpp
 listBox->addItem("New Item");           // Add to end
 listBox->removeItem(index);             // Remove by index
@@ -32,6 +34,7 @@ const auto& items = listBox->getItems(); // Get all items
 **Scrolling**: ListBox automatically provides scrolling when content exceeds the visible area. Users can use mouse wheel or click-and-drag to scroll.
 
 ## Building
+
 ```bash
 cd /home/atom/projects/bombfork/prong
 mise build-examples
@@ -64,12 +67,14 @@ mise build-examples
 6. **Clear**: Click "Clear All" to empty the task list
 
 **Multi-selection Example** (not in basic example):
+
 ```cpp
 // For multi-selection support, you would need to track multiple indices
 // and modify the ListBox to support multiple selections
 ```
 
 **Common Use Cases**:
+
 - File browsers (list of files)
 - Settings panels (list of options)
 - Contact lists
@@ -80,6 +85,7 @@ mise build-examples
 - Message/email lists
 
 **Integration with Other Components**:
+
 ```cpp
 // Example: Master-detail pattern
 auto listBox = create<ListBox>()

--- a/examples/intermediate/01_nested_panels/README.md
+++ b/examples/intermediate/01_nested_panels/README.md
@@ -12,7 +12,7 @@ This example demonstrates complex nested layout composition in Prong, showing ho
 
 ## Layout Structure
 
-```
+```text
 Root Panel (FlexLayout ROW)
 ├── Left Panel (StackLayout VERTICAL)
 │   ├── Action 1 Button
@@ -62,18 +62,21 @@ centerPanel->setLayoutManager(std::move(gridLayout));
 ### When to Use Each Layout Manager
 
 **FlexLayout**: Use when you need:
+
 - Flexible space distribution
 - Alignment control (justify, align)
 - Grow/shrink behavior
 - Gaps between items
 
 **GridLayout**: Use when you need:
+
 - Fixed rows and columns
 - Uniform cell sizes
 - Regular grid patterns
 - Equal spacing
 
 **StackLayout**: Use when you need:
+
 - Simple sequential arrangement
 - Horizontal or vertical stacking
 - Consistent spacing
@@ -92,6 +95,7 @@ auto centerButton = create<Button>("Centered\nAction")
 ```
 
 This is useful when:
+
 - You need precise control over a few elements
 - Layout managers would be overkill
 - You're creating custom component internals

--- a/examples/intermediate/02_responsive_ui/README.md
+++ b/examples/intermediate/02_responsive_ui/README.md
@@ -12,6 +12,7 @@ This example demonstrates how Prong components adapt to window resizing using re
 ## Resize Behaviors Demonstrated
 
 ### 1. FIXED (Left Panel - Purple)
+
 ```cpp
 fixedPanel->setResizeBehavior(Component::ResizeBehavior::FIXED);
 ```
@@ -19,11 +20,13 @@ fixedPanel->setResizeBehavior(Component::ResizeBehavior::FIXED);
 **Behavior**: Component maintains its original size regardless of window resizing.
 
 **Use cases**:
+
 - Fixed-width sidebars
 - Toolbars with specific dimensions
 - Components that should never change size
 
 ### 2. SCALE (Second Panel - Green)
+
 ```cpp
 scalePanel->setResizeBehavior(Component::ResizeBehavior::SCALE);
 ```
@@ -31,11 +34,13 @@ scalePanel->setResizeBehavior(Component::ResizeBehavior::SCALE);
 **Behavior**: Component scales proportionally with the window. If the window doubles in size, the component doubles in size.
 
 **Use cases**:
+
 - Maintaining relative sizes across different screen resolutions
 - Scaling UI elements uniformly
 - Responsive designs that preserve proportions
 
 ### 3. FILL (Third Panel - Blue)
+
 ```cpp
 fillPanel->setResizeBehavior(Component::ResizeBehavior::FILL);
 ```
@@ -43,11 +48,13 @@ fillPanel->setResizeBehavior(Component::ResizeBehavior::FILL);
 **Behavior**: Component expands to fill all available space in its parent.
 
 **Use cases**:
+
 - Main content areas
 - Flexible panels that should use extra space
 - Dynamic layouts where size is unknown
 
 ### 4. PER-AXIS with CONSTRAINTS (Right Panel - Orange)
+
 ```cpp
 // Fixed width (stays 250px), fill height (stretches vertically)
 constrainedPanel->setAxisResizeBehavior(
@@ -67,6 +74,7 @@ constrainedPanel->setConstraints(constraints);
 **Behavior**: Independent control per axis plus min/max boundaries.
 
 **Use cases**:
+
 - Sidebars that keep width but fill height
 - Headers that fill width but keep height
 - Components that need bounded flexibility
@@ -76,6 +84,7 @@ constrainedPanel->setConstraints(constraints);
 To enable window resizing, you need to:
 
 1. **Set up the resize callback**:
+
 ```cpp
 void framebufferSizeCallback(GLFWwindow* window, int width, int height) {
   if (g_scene) {
@@ -87,12 +96,14 @@ void framebufferSizeCallback(GLFWwindow* window, int width, int height) {
 glfwSetFramebufferSizeCallback(glfwWindow, framebufferSizeCallback);
 ```
 
-2. **Make root component responsive**:
+1. **Make root component responsive**:
+
 ```cpp
 rootPanel->setResizeBehavior(Component::ResizeBehavior::FILL);
 ```
 
 The `Scene::handleResize()` method automatically:
+
 - Updates the scene dimensions
 - Triggers resize events for all children
 - Recalculates layouts
@@ -101,14 +112,18 @@ The `Scene::handleResize()` method automatically:
 ## Choosing the Right Resize Behavior
 
 ### ResizeBehavior (Unified)
+
 Best when both axes should behave the same way:
+
 - `FIXED`: Static components
 - `SCALE`: Proportional scaling
 - `FILL`: Maximum flexibility
 - `MAINTAIN_ASPECT`: Preserve aspect ratio while scaling
 
 ### AxisResizeBehavior (Per-Axis)
+
 Best when axes need different behaviors:
+
 ```cpp
 component->setAxisResizeBehavior(
     Component::AxisResizeBehavior::FIXED,   // Horizontal
@@ -117,6 +132,7 @@ component->setAxisResizeBehavior(
 ```
 
 Common patterns:
+
 - **Sidebar**: FIXED horizontal, FILL vertical
 - **Header**: FILL horizontal, FIXED vertical
 - **Corner panel**: FIXED both (same as ResizeBehavior::FIXED)
@@ -162,6 +178,7 @@ Try these modifications:
 ## Common Patterns
 
 ### Responsive Three-Panel Layout
+
 ```cpp
 // Left sidebar: fixed width, fills height
 leftPanel->setAxisResizeBehavior(
@@ -180,6 +197,7 @@ rightPanel->setAxisResizeBehavior(
 ```
 
 ### Header-Content-Footer
+
 ```cpp
 // Header: fills width, fixed height
 header->setAxisResizeBehavior(

--- a/examples/intermediate/03_event_handling/README.md
+++ b/examples/intermediate/03_event_handling/README.md
@@ -151,6 +151,7 @@ Hover state is updated automatically during event propagation - you just need to
 ## Interactive Example Features
 
 ### Click Tracking
+
 ```cpp
 case Event::Type::MOUSE_PRESS:
   if (event.button == 0) {
@@ -160,6 +161,7 @@ case Event::Type::MOUSE_PRESS:
 ```
 
 ### Drag Tracking
+
 ```cpp
 case Event::Type::MOUSE_PRESS:
   isDragging = true;
@@ -181,6 +183,7 @@ case Event::Type::MOUSE_RELEASE:
 ```
 
 ### Keyboard Shortcuts
+
 ```cpp
 case Event::Type::KEY_PRESS:
   if (focusState == FocusState::FOCUSED) {
@@ -197,6 +200,7 @@ case Event::Type::KEY_PRESS:
 ```
 
 ### Scroll Handling
+
 ```cpp
 case Event::Type::MOUSE_SCROLL:
   // event.scrollX and event.scrollY contain scroll deltas
@@ -220,6 +224,7 @@ Try interacting with the panels to see different event handling patterns!
 ## Common Patterns
 
 ### Button-like Component
+
 ```cpp
 bool handleEventSelf(const Event& event) override {
   if (event.type == Event::Type::MOUSE_PRESS && event.button == 0) {
@@ -231,6 +236,7 @@ bool handleEventSelf(const Event& event) override {
 ```
 
 ### Draggable Component
+
 ```cpp
 bool handleEventSelf(const Event& event) override {
   switch (event.type) {
@@ -253,6 +259,7 @@ bool handleEventSelf(const Event& event) override {
 ```
 
 ### Keyboard-Controlled Component
+
 ```cpp
 bool handleEventSelf(const Event& event) override {
   if (event.type == Event::Type::KEY_PRESS &&

--- a/examples/intermediate/04_dynamic_layout/README.md
+++ b/examples/intermediate/04_dynamic_layout/README.md
@@ -32,6 +32,7 @@ void addPanel() {
 ```
 
 Key points:
+
 - Create component with builder pattern
 - Transfer ownership with `std::move()`
 - Call `invalidateLayout()` to update positions
@@ -50,6 +51,7 @@ void removePanel() {
 ```
 
 Key points:
+
 - Get reference to children vector
 - Pass pointer to child you want removed
 - Layout is automatically recalculated
@@ -97,6 +99,7 @@ The same children are automatically repositioned according to the new layout man
 ### When to Invalidate Layout
 
 Call `invalidateLayout()` when:
+
 - Adding or removing children
 - Changing layout manager
 - Modifying layout properties (gap, direction, etc.)
@@ -162,6 +165,7 @@ This example uses a common pattern: control panel + content area
 ```
 
 Benefits:
+
 - Separate controls from content
 - Easy to add new operations
 - Clear visual organization

--- a/hk.pkl
+++ b/hk.pkl
@@ -13,6 +13,22 @@ hooks {
                 fix = "mise run format {{ files }}"
                 stage = List("**/*.cpp", "**/*.h")
             }
+            ["markdown-lint"] {
+                // Lint markdown files
+                glob = List("**/*.md")
+                check = "mise run markdown-check {{ files }}"
+                fix = "mise run markdown-fix {{ files }}"
+                stage = List("**/*.md")
+            }
+        }
+    }
+    ["pre-push"] {
+        fix = false  // No auto-fixing on pre-push
+        steps = new Mapping<String, Step> {
+            ["build-validation"] {
+                // Run full build validation before pushing
+                check = "mise run build-ci"
+            }
         }
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -5,7 +5,9 @@ This directory contains unit tests for the Prong UI Framework, using CTest as th
 ## Test Files
 
 ### `test_color.cpp`
+
 Tests the `Color` class from `bombfork::prong::theming`:
+
 - Color construction (default and parameterized)
 - Equality operators
 - Predefined colors (WHITE, BLACK, RED, GREEN, BLUE, etc.)
@@ -15,7 +17,9 @@ Tests the `Color` class from `bombfork::prong::theming`:
 - Constexpr operations and compile-time evaluation
 
 ### `test_coordinate_system.cpp`
+
 Tests the `CoordinateSystem` class from `bombfork::prong`:
+
 - Viewport construction and updates
 - Camera position and zoom management
 - Cell size calculations with zoom
@@ -41,20 +45,23 @@ cmake --build .
 
 ## Running Tests
 
-### Run all tests with CTest:
+### Run all tests with CTest
+
 ```bash
 cd build
 ctest --output-on-failure
 ```
 
-### Run individual test executables:
+### Run individual test executables
+
 ```bash
 cd build
 ./tests/test_color
 ./tests/test_coordinate_system
 ```
 
-### Verbose test output:
+### Verbose test output
+
 ```bash
 ctest --verbose
 ```
@@ -62,6 +69,7 @@ ctest --verbose
 ## Test Framework
 
 These tests use a simple assertion-based approach with:
+
 - `assert()` for test conditions
 - Custom helper functions for floating-point comparisons
 - Clear test function organization
@@ -74,12 +82,14 @@ To add a new test:
 
 1. Create a new `.cpp` file in the `tests/` directory
 2. Add the test executable to `CMakeLists.txt`:
+
    ```cmake
    add_executable(test_newfeature test_newfeature.cpp)
    target_link_libraries(test_newfeature PRIVATE prong)
    set_target_properties(test_newfeature PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
    add_test(NAME NewFeatureTest COMMAND test_newfeature)
    ```
+
 3. Follow the existing test structure with:
    - Individual test functions for each feature
    - A main() function that runs all tests


### PR DESCRIPTION
## Summary

This PR implements the improvements requested in issue #115 by adding:

- **Markdown linting** to the pre-commit hook
- **Pre-push build validation** to prevent broken code from reaching the remote

## Changes Made

### 1. Markdown Linting Integration

**Added rumdl as markdown linter:**
- Added `rumdl` (Rust Markdown Linter) to `.mise.toml` tools
- Created `mise run markdown-check` task for checking markdown files
- Created `mise run markdown-fix` task for auto-fixing markdown issues

**Updated pre-commit hook:**
- Added markdown linting step to `hk.pkl` pre-commit hook
- Automatically checks all `**/*.md` files
- Auto-fixes violations when possible (blank lines, heading spacing, list formatting)
- Re-stages fixed markdown files automatically

### 2. Pre-Push Build Validation

**Added pre-push hook:**
- New `pre-push` hook in `hk.pkl` that runs `mise run build-ci`
- Ensures library, tests, and examples build successfully before push
- Verifies no formatting violations exist
- Prevents CI failures and broken pushes

### 3. Markdown Formatting Applied

- Fixed 343 auto-fixable markdown issues across 32 files
- Addressed spacing, blank lines, and list formatting issues
- Remaining line length warnings (MD013) left for manual review

## Testing

- ✅ Git hooks installed successfully with `hk install`
- ✅ Pre-commit hook runs `clang-format` on C++ files
- ✅ Pre-commit hook runs `rumdl fmt` on markdown files
- ✅ Pre-push hook runs full build validation
- ✅ Committed and pushed successfully with new hooks

## Benefits

1. **Consistency**: All markdown files follow consistent formatting style
2. **Early detection**: Catch build failures locally before pushing
3. **CI efficiency**: Fewer failed CI runs due to formatting or build issues
4. **Documentation quality**: Better docs with enforced markdown standards

## Related Issue

Closes #115

## Documentation

- Git hooks configuration documented in `hk.pkl` with inline comments
- Mise tasks documented with clear descriptions
- Hook behavior documented in `CONTRIBUTING.md`

Fixes #115