### PR TITLE
[#114.1] Add iwyu enforcement to glfw_adapters and demo_app

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -75,6 +75,11 @@ target_include_directories(glfw_adapters PUBLIC
 
 target_compile_features(glfw_adapters PUBLIC cxx_std_20)
 
+# Enable iwyu for glfw_adapters
+set_target_properties(glfw_adapters PROPERTIES
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
+)
+
 # === Demo App Example ===
 
 add_executable(prong_demo_app
@@ -99,6 +104,11 @@ target_compile_features(prong_demo_app PRIVATE cxx_std_20)
 
 # Suppress unused function warnings for STB (header-only library with many utilities)
 target_compile_options(prong_demo_app PRIVATE -Wno-unused-function)
+
+# Enable iwyu for prong_demo_app
+set_target_properties(prong_demo_app PROPERTIES
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
+)
 
 # Make example depend on formatting target
 add_dependencies(prong_demo_app format-example-sources)

--- a/examples/demo_app/main.cpp
+++ b/examples/demo_app/main.cpp
@@ -11,10 +11,10 @@
 #include "scenes/demo_scene.h"
 #include <GLFW/glfw3.h>
 
-#include <cmath>
 #include <filesystem>
 #include <iostream>
 #include <memory>
+#include <string>
 
 #ifdef __linux__
 #include <sys/types.h>

--- a/include/bombfork/prong/components/viewport.h
+++ b/include/bombfork/prong/components/viewport.h
@@ -169,12 +169,6 @@ private:
   PanChangedCallback panCallback;
   SelectionCallback selectionCallback;
 
-  // Scrollbar state
-  bool horizontalScrollbarHover = false;
-  bool verticalScrollbarHover = false;
-  bool horizontalScrollbarDrag = false;
-  bool verticalScrollbarDrag = false;
-
 public:
   explicit Viewport() : Component(nullptr, "Viewport") {
     // Initialize default theme


### PR DESCRIPTION
## Summary

Implements issue #117, part of #114 (Make include-what-you-use mandatory for all example builds).

This PR adds `CXX_INCLUDE_WHAT_YOU_USE` enforcement to:
- `glfw_adapters` library
- `prong_demo_app` executable

## Changes

### CMakeLists.txt Updates
- Added iwyu property to `glfw_adapters` library target
- Added iwyu property to `prong_demo_app` executable target
- Both targets now use `--error` flag to fail builds on include violations

### Include Fixes
- **demo_app/main.cpp**: Added missing `#include <string>`, removed unused `#include <cmath>`
- **viewport.h**: Removed 4 unused private scrollbar state fields that triggered `-Wunused-private-field` warnings

## Verification

All checks pass:
- ✅ `mise build` - No iwyu errors
- ✅ `mise build-examples` - Demo app builds successfully
- ✅ `mise test` - All 17 tests pass
- ✅ Pre-commit hooks (format-check) - Pass
- ✅ Pre-push hooks (build-validation) - Pass

## Impact

- Enforces include hygiene for demo infrastructure
- Prevents future include violations in examples
- Sets foundation for adding iwyu to all other examples (#118, #119, #120)

## Related Issues

- Closes #117
- Part of #114