### PR TITLE
[#114.2] Add iwyu enforcement to basic examples

### DIFF
--- a/examples/basic/01_hello_button/CMakeLists.txt
+++ b/examples/basic/01_hello_button/CMakeLists.txt
@@ -30,4 +30,5 @@ add_dependencies(01_hello_button format-example-sources)
 # Output to build/examples/basic/01_hello_button/
 set_target_properties(01_hello_button PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/01_hello_button"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/01_hello_button/main.cpp
+++ b/examples/basic/01_hello_button/main.cpp
@@ -13,10 +13,14 @@
 #include "../../adapters/simple_opengl_renderer.h"
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <utility>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::examples;

--- a/examples/basic/02_stack_layout/CMakeLists.txt
+++ b/examples/basic/02_stack_layout/CMakeLists.txt
@@ -23,4 +23,5 @@ add_dependencies(02_stack_layout format-example-sources)
 
 set_target_properties(02_stack_layout PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/02_stack_layout"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/02_stack_layout/main.cpp
+++ b/examples/basic/02_stack_layout/main.cpp
@@ -13,11 +13,15 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/stack_layout.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <utility>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::examples;

--- a/examples/basic/03_flex_layout/CMakeLists.txt
+++ b/examples/basic/03_flex_layout/CMakeLists.txt
@@ -23,4 +23,5 @@ add_dependencies(03_flex_layout format-example-sources)
 
 set_target_properties(03_flex_layout PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/03_flex_layout"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/03_flex_layout/main.cpp
+++ b/examples/basic/03_flex_layout/main.cpp
@@ -14,11 +14,17 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/flex_layout.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::examples;

--- a/examples/basic/04_grid_layout/CMakeLists.txt
+++ b/examples/basic/04_grid_layout/CMakeLists.txt
@@ -23,4 +23,5 @@ add_dependencies(04_grid_layout format-example-sources)
 
 set_target_properties(04_grid_layout PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/04_grid_layout"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/04_grid_layout/main.cpp
+++ b/examples/basic/04_grid_layout/main.cpp
@@ -14,11 +14,16 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/grid_layout.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 using namespace bombfork::prong;

--- a/examples/basic/05_dock_layout/CMakeLists.txt
+++ b/examples/basic/05_dock_layout/CMakeLists.txt
@@ -23,4 +23,5 @@ add_dependencies(05_dock_layout format-example-sources)
 
 set_target_properties(05_dock_layout PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/05_dock_layout"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/05_dock_layout/main.cpp
+++ b/examples/basic/05_dock_layout/main.cpp
@@ -14,11 +14,18 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/dock_layout.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::examples;

--- a/examples/basic/06_flow_layout/CMakeLists.txt
+++ b/examples/basic/06_flow_layout/CMakeLists.txt
@@ -23,4 +23,5 @@ add_dependencies(06_flow_layout format-example-sources)
 
 set_target_properties(06_flow_layout PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/06_flow_layout"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/06_flow_layout/main.cpp
+++ b/examples/basic/06_flow_layout/main.cpp
@@ -14,11 +14,16 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/flow_layout.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
 #include <vector>
 
 using namespace bombfork::prong;

--- a/examples/basic/07_text_input/CMakeLists.txt
+++ b/examples/basic/07_text_input/CMakeLists.txt
@@ -24,4 +24,5 @@ add_dependencies(07_text_input format-example-sources)
 
 set_target_properties(07_text_input PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/07_text_input"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/07_text_input/main.cpp
+++ b/examples/basic/07_text_input/main.cpp
@@ -13,15 +13,21 @@
 #include "../../adapters/glfw_window_adapter.h"
 #include "../../adapters/simple_opengl_renderer.h"
 #include "../../common/glfw_adapters/glfw_adapters.h"
+#include "glfw_clipboard.h"
+#include "glfw_keyboard.h"
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
 #include <bombfork/prong/components/text_input.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 
+#include <functional>
 #include <iostream>
 #include <memory>
+#include <string>
+#include <utility>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::examples;

--- a/examples/basic/08_list_box/CMakeLists.txt
+++ b/examples/basic/08_list_box/CMakeLists.txt
@@ -23,4 +23,5 @@ add_dependencies(08_list_box format-example-sources)
 
 set_target_properties(08_list_box PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/basic/08_list_box"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/basic/08_list_box/main.cpp
+++ b/examples/basic/08_list_box/main.cpp
@@ -16,12 +16,15 @@
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/list_box.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 using namespace bombfork::prong;


### PR DESCRIPTION
## Summary
- Added `CXX_INCLUDE_WHAT_YOU_USE` property to all 8 basic example CMakeLists.txt files
- Fixed missing includes in example source files to satisfy iwyu requirements
- All examples now build successfully with iwyu `--error` flag enabled

## Changes

### CMakeLists.txt (8 files)
Added iwyu enforcement to:
- 01_hello_button
- 02_stack_layout
- 03_flex_layout
- 04_grid_layout
- 05_dock_layout
- 06_flow_layout
- 07_text_input
- 08_list_box

### Source Files (8 files)
Added missing includes to satisfy iwyu:
- Standard library headers: `<functional>`, `<memory>`, `<utility>`, `<string>`, `<vector>`, `<optional>`
- Prong headers: `<bombfork/prong/core/component.h>`
- GLFW adapters (text_input only): clipboard and keyboard headers

## Test Plan
- [x] All 8 basic examples build successfully with `mise build-examples`
- [x] iwyu checks pass with `--error` flag (build would fail otherwise)
- [x] Pre-commit hooks passed (clang-format)
- [x] Pre-push hooks passed (build validation)

## Related Issues
Part of #114 - Make include-what-you-use mandatory for all example builds
Closes #118