### PR TITLE
[#114.4] Add iwyu enforcement to advanced examples

### DIFF
--- a/examples/advanced/01_custom_component/CMakeLists.txt
+++ b/examples/advanced/01_custom_component/CMakeLists.txt
@@ -30,4 +30,5 @@ add_dependencies(01_custom_component format-example-sources)
 # Output to build/examples/advanced/01_custom_component/
 set_target_properties(01_custom_component PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/advanced/01_custom_component"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/advanced/01_custom_component/main.cpp
+++ b/examples/advanced/01_custom_component/main.cpp
@@ -14,18 +14,21 @@
 #include "../../adapters/glfw_window_adapter.h"
 #include "../../adapters/simple_opengl_renderer.h"
 #include <GLFW/glfw3.h>
-#include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
 #include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/event.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/rendering/irenderer.h>
+#include <bombfork/prong/theming/color.h>
 
 #include <algorithm>
 #include <cmath>
 #include <functional>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::core;
@@ -42,7 +45,6 @@ private:
   float selectedG = 0.5f;
   float selectedB = 0.0f;
 
-  bool isDragging = false;
   ColorChangeCallback onColorChange;
 
 public:

--- a/examples/advanced/02_custom_layout/CMakeLists.txt
+++ b/examples/advanced/02_custom_layout/CMakeLists.txt
@@ -21,4 +21,5 @@ add_dependencies(02_custom_layout format-example-sources)
 
 set_target_properties(02_custom_layout PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/advanced/02_custom_layout"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/advanced/02_custom_layout/main.cpp
+++ b/examples/advanced/02_custom_layout/main.cpp
@@ -12,9 +12,15 @@
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/layout_manager.h>
+#include <bombfork/prong/theming/color.h>
 
 #include <cmath>
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::layout;

--- a/examples/advanced/03_custom_renderer/CMakeLists.txt
+++ b/examples/advanced/03_custom_renderer/CMakeLists.txt
@@ -21,4 +21,5 @@ add_dependencies(03_custom_renderer format-example-sources)
 
 set_target_properties(03_custom_renderer PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/advanced/03_custom_renderer"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/advanced/03_custom_renderer/main.cpp
+++ b/examples/advanced/03_custom_renderer/main.cpp
@@ -12,11 +12,16 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/rendering/irenderer.h>
+#include <bombfork/prong/theming/color.h>
 
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <utility>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::rendering;

--- a/examples/advanced/04_performance/CMakeLists.txt
+++ b/examples/advanced/04_performance/CMakeLists.txt
@@ -21,4 +21,5 @@ add_dependencies(04_performance format-example-sources)
 
 set_target_properties(04_performance PROPERTIES
     RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/examples/advanced/04_performance"
+    CXX_INCLUDE_WHAT_YOU_USE "${IWYU_PATH};-Xiwyu;--error;-Xiwyu;--verbose=3"
 )

--- a/examples/advanced/04_performance/main.cpp
+++ b/examples/advanced/04_performance/main.cpp
@@ -8,12 +8,17 @@
 #include <GLFW/glfw3.h>
 #include <bombfork/prong/components/button.h>
 #include <bombfork/prong/components/panel.h>
+#include <bombfork/prong/core/component.h>
 #include <bombfork/prong/core/component_builder.h>
 #include <bombfork/prong/core/scene.h>
 #include <bombfork/prong/layout/grid_layout.h>
 
 #include <chrono>
+#include <functional>
 #include <iostream>
+#include <memory>
+#include <string>
+#include <utility>
 
 using namespace bombfork::prong;
 using namespace bombfork::prong::layout;


### PR DESCRIPTION
## Summary

Adds `CXX_INCLUDE_WHAT_YOU_USE` property to all 4 advanced example executables, completing issue #114 by enforcing include-what-you-use for all advanced examples.

## Changes

- Added iwyu enforcement to `01_custom_component/CMakeLists.txt`
- Added iwyu enforcement to `02_custom_layout/CMakeLists.txt`
- Added iwyu enforcement to `03_custom_renderer/CMakeLists.txt`
- Added iwyu enforcement to `04_performance/CMakeLists.txt`
- Fixed missing includes in example source files
- Removed unused private field `isDragging` in `01_custom_component/main.cpp`

## Test Plan

- ✅ `mise build-examples` succeeds without iwyu errors
- ✅ All advanced examples build successfully with iwyu enforcement
- ✅ Pre-push hooks (format check and build validation) pass

Resolves #120
Part of #114